### PR TITLE
Adding Linting Rules and Auto-Linting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+# http://editorconfig.org
+
+# A special property that should be specified at the top of the file outside of
+# any sections. Set to true to stop .editor config file search on current file
+root = true
+
+[*]
+# Indentation style
+# Possible values - tab, space
+indent_style = space
+
+# Indentation size in single-spaced characters
+# Possible values - an integer, tab
+indent_size = 2
+
+# Line ending file format
+# Possible values - lf, crlf, cr
+end_of_line = lf
+
+# File character encoding
+# Possible values - latin1, utf-8, utf-16be, utf-16le
+charset = utf-8
+
+# Denotes whether to trim whitespace at the end of lines
+# Possible values - true, false
+trim_trailing_whitespace = true
+
+# Denotes whether file should end with a newline
+# Possible values - true, false
+insert_final_newline = true

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,15 +47,6 @@
         "printWidth": 100,
         "trailingComma": "es5"
       }
-    ],
-
-    "unicorn/filename-case": ["warn", { "case": "kebabCase" }],
-    "unicorn/throw-new-error": ["error"],
-    "unicorn/no-array-instanceof": ["error"],
-    "unicorn/no-new-buffer": ["error"],
-    "unicorn/no-hex-escape": ["error"],
-    "unicorn/prefer-starts-ends-with": ["warn"],
-
-    "promise/catch-or-return": ["error"]
+    ]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,61 @@
+{
+  "root": true,
+  "parserOptions": {
+    "ecmaVersion": 8
+  },
+  "plugins": ["prettier"],
+  "rules": {
+    "no-debugger": ["error"],
+    "no-regex-spaces": ["error"],
+    "no-unsafe-negation": ["error"],
+    "curly": ["error", "multi-or-nest", "consistent"],
+    "dot-location": ["error", "property"],
+    "dot-notation": ["error"],
+    "eqeqeq": ["error", "smart"],
+    "no-else-return": ["error"],
+    "no-extra-bind": ["error"],
+    "no-extra-label": ["error"],
+    "no-floating-decimal": ["error"],
+    "no-implicit-coercion": ["error", { "allow": ["!!"] }],
+    "wrap-iife": ["error", "inside"],
+    "strict": ["error", "global"],
+    "func-call-spacing": ["error", "never"],
+    "comma-style": ["error", "last"],
+    "keyword-spacing": ["error"],
+    "linebreak-style": ["error", "unix"],
+    "new-parens": ["error"],
+    "no-lonely-if": ["error"],
+    "no-multiple-empty-lines": ["error", { "max": 2, "maxEOF": 1 }],
+    "no-whitespace-before-property": ["error"],
+    "semi": ["error", "always"],
+    "arrow-body-style": ["error", "as-needed"],
+    "arrow-parens": ["error", "as-needed"],
+    "arrow-spacing": ["error"],
+    "no-useless-computed-key": ["error"],
+    "no-useless-rename": ["error"],
+    "no-var": ["error"],
+    "prefer-spread": ["error"],
+    "prefer-template": ["error"],
+    "rest-spread-spacing": ["error", "never"],
+    "prefer-const": ["warn", { "destructuring": "all" }],
+    "no-unreachable": ["warn"],
+    "no-unused-vars": ["warn", { "args": "none" }],
+
+    "prettier/prettier": [
+      "warn",
+      {
+        "printWidth": 100,
+        "trailingComma": "es5"
+      }
+    ],
+
+    "unicorn/filename-case": ["warn", { "case": "kebabCase" }],
+    "unicorn/throw-new-error": ["error"],
+    "unicorn/no-array-instanceof": ["error"],
+    "unicorn/no-new-buffer": ["error"],
+    "unicorn/no-hex-escape": ["error"],
+    "unicorn/prefer-starts-ends-with": ["warn"],
+
+    "promise/catch-or-return": ["error"]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ node_modules/
 package-lock.json
 .env
 start-local-server
-
+coverage

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,9 @@ before_install:
 script: "npm run test"
 
 # Send coverage data to Coveralls
-#after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
-
+after_success:
+  - npm run coverage
+  
 #deploy:
 #  provider: script
 #  skip_cleanup: true

--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ BITCOINCOM_BASEURL=https://bch-insight.bitpay.com/api/ RPC_BASEURL=http://your.n
 
 #### View in browser
 
-Finally open `http://localhost:3000/` and confirm you see the GUI.
+Finally open `http://localhost:3000/` and confirm you see the GUI

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "body-parser": "~1.17.1",
     "cookie-parser": "~1.4.3",
     "cors": "^2.8.3",
+    "coveralls": "^3.0.2",
     "debug": "~2.6.3",
     "dotenv": "^4.0.0",
     "elasticsearch": "^13.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "node app.js",
     "dev": "nodemon app.js",
     "test": "mocha --require babel-core/register --timeout 5000",
-    "coverage": "nyc report --reporter=text-lcov | coveralls"
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "coverage:report": "nyc --reporter=html mocha --require babel-core/register --timeout 5000"
   },
   "engines": {
     "node": ">=8.11.3"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint": "^5.5.0",
     "eslint-config-prettier": "^3.0.1",
     "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-prettier": "^2.6.2",
     "eslint-plugin-standard": "^4.0.0",
     "node-mocks-http": "^1.7.0",
     "nodemon": "^1.18.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "node app.js",
     "dev": "nodemon app.js",
-    "test": "nyc mocha --require babel-core/register --timeout 5000"
+    "test": "nyc mocha --require babel-core/register --timeout 5000",
+    "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "engines": {
     "node": ">=8.11.3"
@@ -19,7 +20,6 @@
     "body-parser": "~1.17.1",
     "cookie-parser": "~1.4.3",
     "cors": "^2.8.3",
-    "coveralls": "^3.0.2",
     "debug": "~2.6.3",
     "dotenv": "^4.0.0",
     "elasticsearch": "^13.0.1",
@@ -44,6 +44,7 @@
     "chai": "^4.1.2",
     "node-mocks-http": "^1.7.0",
     "nodemon": "^1.18.1",
-    "nyc": "^11.6.0"
+    "nyc": "^11.6.0",
+    "coveralls": "^3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node app.js",
     "dev": "nodemon app.js",
-    "test": "nyc mocha --require babel-core/register --timeout 5000",
+    "test": "mocha --require babel-core/register --timeout 5000",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -43,9 +43,14 @@
   },
   "devDependencies": {
     "chai": "^4.1.2",
+    "coveralls": "^3.0.2",
+    "eslint": "^5.5.0",
+    "eslint-config-prettier": "^3.0.1",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-standard": "^4.0.0",
     "node-mocks-http": "^1.7.0",
     "nodemon": "^1.18.1",
     "nyc": "^11.6.0",
-    "coveralls": "^3.0.2"
+    "prettier": "^1.14.2"
   }
 }

--- a/routes/address.js
+++ b/routes/address.js
@@ -37,16 +37,20 @@ router.get('/', config.addressRateLimit1, (req, res, next) => {
 router.get('/details/:address', config.addressRateLimit2, (req, res, next) => {
   try {
     let addresses = JSON.parse(req.params.address);
+
+    // Enforce no more than 20 addresses.
     if(addresses.length > 20) {
       res.json({
         error: 'Array too large. Max 20 addresses'
       });
     }
+
     let result = [];
     addresses = addresses.map((address) => {
       let path = `${process.env.BITCOINCOM_BASEURL}addr/${BITBOX.Address.toLegacyAddress(address)}`;
-      return axios.get(path)
+      return axios.get(path) // Returns a promise.
     })
+
     axios.all(addresses)
     .then(axios.spread((...args) => {
       for (let i = 0; i < args.length; i++) {

--- a/test/address.js
+++ b/test/address.js
@@ -3,6 +3,12 @@ let assert = require('assert');
 let httpMocks = require("node-mocks-http");
 let addressRoute = require('../routes/address');
 
+const util = require("util");
+util.inspect.defaultOptions = {
+  showHidden: true,
+  colors: true,
+};
+
 describe("#AddressRouter", () => {
   describe("#root", () => {
     it("should return 'address' for GET /", () => {
@@ -19,7 +25,7 @@ describe("#AddressRouter", () => {
       assert.deepEqual(JSON.parse(actualResponseBody), expectedResponseBody);
     });
   });
-  /*
+/*
   describe("#AddressDetails", () => {
     it("should GET /details/:address single address", (done) => {
       let mockRequest = httpMocks.createRequest({
@@ -38,6 +44,7 @@ describe("#AddressRouter", () => {
       });
     });
 
+    /*
     it("should GET /details/:address array of addresses", (done) => {
       let mockRequest = httpMocks.createRequest({
         method: "GET",
@@ -54,8 +61,9 @@ describe("#AddressRouter", () => {
         done();
       });
     });
+    
   });
-
+/*
   describe("#AddressUtxo", () => {
     it("should GET /utxo/:address single address", (done) => {
       let mockRequest = httpMocks.createRequest({

--- a/test/address.js
+++ b/test/address.js
@@ -1,7 +1,9 @@
-let chai = require('chai');
-let assert = require('assert');
-let httpMocks = require("node-mocks-http");
-let addressRoute = require('../routes/address');
+"use strict";
+
+//const chai = require("chai");
+const assert = require("assert");
+const httpMocks = require("node-mocks-http");
+const addressRoute = require("../routes/address");
 
 const util = require("util");
 util.inspect.defaultOptions = {
@@ -12,20 +14,20 @@ util.inspect.defaultOptions = {
 describe("#AddressRouter", () => {
   describe("#root", () => {
     it("should return 'address' for GET /", () => {
-      let mockRequest = httpMocks.createRequest({
+      const mockRequest = httpMocks.createRequest({
         method: "GET",
-        url: "/"
+        url: "/",
       });
-      let mockResponse = httpMocks.createResponse();
+      const mockResponse = httpMocks.createResponse();
       addressRoute(mockRequest, mockResponse);
-      let actualResponseBody = mockResponse._getData();
-      let expectedResponseBody = {
-        status: 'address'
+      const actualResponseBody = mockResponse._getData();
+      const expectedResponseBody = {
+        status: "address",
       };
       assert.deepEqual(JSON.parse(actualResponseBody), expectedResponseBody);
     });
   });
-/*
+  /*
   describe("#AddressDetails", () => {
     it("should GET /details/:address single address", (done) => {
       let mockRequest = httpMocks.createRequest({
@@ -61,7 +63,7 @@ describe("#AddressRouter", () => {
         done();
       });
     });
-    
+
   });
 /*
   describe("#AddressUtxo", () => {


### PR DESCRIPTION
This PR adds the following:
* It adds `coveralls` as an NPM dependency for when we're ready to plug into that system.
* Removes `nyc` from the test to speed up unit tests in Travis CI. Coverage reporting is run *after* tests have passed.
* Adds a script to generate html coverage reports.
* Adds eslint and Prettier rules for auto-linting in the Atom text editor.