### PR TITLE
Option to remove transaction hash list from /blockchain/getBlock

### DIFF
--- a/public/bitcoin-com-rest-v1.json
+++ b/public/bitcoin-com-rest-v1.json
@@ -314,7 +314,7 @@
           "blockchain"
         ],
         "summary": "Information about block hash.",
-        "description": "If verbose is false, returns a string that is serialized, hex-encoded data for block 'hash'. If verbose is true, returns an Object with information about block hash.",
+        "description": "If verbose is false, returns a string that is serialized, hex-encoded data for block 'hash'. If verbose is true, returns an Object with information about block hash. The list of transactions hashes can be omitted from the object by setting txs to false",
         "operationId": "getBlock",
         "parameters": [
           {
@@ -331,6 +331,16 @@
             "name": "verbose",
             "in": "query",
             "description": "true for a json object, false for the hex encoded data",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          },
+          {
+            "name": "txs",
+            "in": "query",
+            "description": "true to return list of tx hashes, false to omit list of tx hashes",
             "required": false,
             "schema": {
               "type": "boolean",

--- a/routes/blockchain.js
+++ b/routes/blockchain.js
@@ -81,6 +81,11 @@ router.get('/getBlock/:hash', config.blockchainRateLimit2, async (req, res, next
   if(req.query.verbose && req.query.verbose === 'true') {
     verbose = true;
   }
+  
+  let showTxs = true;
+  if(req.query.txs && req.query.txs === 'false') {
+    showTxs = false;
+  }
 
   requestConfig.data.id = "getblock";
   requestConfig.data.method = "getblock";
@@ -91,6 +96,7 @@ router.get('/getBlock/:hash', config.blockchainRateLimit2, async (req, res, next
 
   try {
     let response = await BitboxHTTP(requestConfig);
+    if(!showTxs) delete response.data.result.tx;
     res.json(response.data.result);
   } catch (error) {
     res.status(500).send(error.response.data.error);


### PR DESCRIPTION
The list of transactions can get very long if the blocks are big. Usually people just want basic info about the block, such as the size. This will be helpful to reduce latency for applications after a block is found.