### PR TITLE
Change verbose to integer for getRawTransaction

### DIFF
--- a/routes/rawtransactions.js
+++ b/routes/rawtransactions.js
@@ -226,8 +226,8 @@ router.get(
   "/getRawTransaction/:txid",
   config.rawTransactionsRateLimit4,
   (req, res, next) => {
-    let verbose = false
-    if (req.query.verbose && req.query.verbose === "true") verbose = true
+    let verbose = 0
+    if (req.query.verbose && req.query.verbose === "true") verbose = 1
 
     try {
       let txids = JSON.parse(req.params.txid)


### PR DESCRIPTION
I'm running Bitcoin Unlimited 1.5.0.0 and I'm getting the error `JSON value is not an integer as expected` now with getRawTransaction. Changing the verbose variable to an integer fixes it, since the actual rpc command takes an integer. I haven't tested this with any other node version.