### PR TITLE
pandacash-cli replaced with pandacash-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest.bitcoin.com",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "description": "REST API for Bitcoin.com's Cloud",
   "author": "Gabriel Cardona @ Bitcoin.com",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "node-mocks-http": "^1.7.0",
     "nodemon": "^1.18.1",
     "nyc": "^11.6.0",
-    "pandacash-cli": "^0.4.0",
+    "pandacash-core": "^0.1.0",
     "prettier": "^1.14.2",
     "sinon": "^6.3.4",
     "typescript": "^3.1.4"

--- a/test/v2/helpers/panda.js
+++ b/test/v2/helpers/panda.js
@@ -3,7 +3,7 @@
 /**
  * Read more about panda here: https://panda-suite.github.io/
  */
-const panda = require("pandacash-cli")
+const panda = require("pandacash-core")
 
 const runLocalNode = done => {
   const server = panda.server({
@@ -14,7 +14,10 @@ const runLocalNode = done => {
     debug: false
   })
 
-  server.listen(48332, (err, pandaCashCore) => {
+  server.listen({
+    port: 48332,
+    walletPort: 48333,
+  }, (err, pandaCashCore) => {
     if (err) return console.error(err)
 
     done()


### PR DESCRIPTION
For testing of the replaced library, run:
npm run test-v2:blockchain