### PR TITLE
GET and POST endpoints added for Insight API Calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ test-local-server
 coverage
 start-my-infra
 dist/routes/**
-
+test-v1

--- a/src/routes/v2/address.ts
+++ b/src/routes/v2/address.ts
@@ -1,11 +1,14 @@
 "use strict"
 
-const express = require("express")
-const router = express.Router()
-const axios = require("axios")
-const RateLimit = require("express-rate-limit")
+import * as express from "express"
+import * as requestUtils from "./services/requestUtils"
+import axios from "axios"
 const logger = require("./logging.js")
 const routeUtils = require("./route-utils")
+
+//const router = express.Router()
+const router: express.Router = express.Router()
+const RateLimit = require("express-rate-limit")
 
 // Used for processing error messages before sending them to the user.
 const util = require("util")
@@ -14,11 +17,20 @@ util.inspect.defaultOptions = { depth: 1 }
 const BITBOXCli = require("bitbox-sdk/lib/bitbox-sdk").default
 const BITBOX = new BITBOXCli()
 
-const config = {
+interface IRLConfig {
+  [addressRateLimit1: string]: any
+  addressRateLimit2: any
+  addressRateLimit3: any
+  addressRateLimit4: any
+  addressRateLimit5: any
+}
+
+const config: IRLConfig = {
   addressRateLimit1: undefined,
   addressRateLimit2: undefined,
   addressRateLimit3: undefined,
-  addressRateLimit4: undefined
+  addressRateLimit4: undefined,
+  addressRateLimit5: undefined
 }
 
 let i = 1
@@ -27,7 +39,7 @@ while (i < 6) {
     windowMs: 60000, // 1 hour window
     delayMs: 0, // disable delaying - full speed until the max limit is reached
     max: 60, // start blocking after 60 requests
-    handler: function(req, res /*next*/) {
+    handler: function(req: express.Request, res: express.Response /*next*/) {
       res.format({
         json: function() {
           res.status(500).json({
@@ -48,14 +60,22 @@ router.post("/unconfirmed/:address", config.addressRateLimit4, unconfirmed)
 router.post("/transactions/:address", config.addressRateLimit5, transactions)
 
 // Root API endpoint. Simply acknowledges that it exists.
-function root(req, res, next) {
+function root(
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) {
   return res.json({ status: "address" })
 }
 
 // Retrieve details on an address.
 // curl -d '{"addresses": ["bchtest:qzjtnzcvzxx7s0na88yrg3zl28wwvfp97538sgrrmr", "bchtest:qp6hgvevf4gzz6l7pgcte3gaaud9km0l459fa23dul"]}' -H "Content-Type: application/json" http://localhost:3000/v2/address/details
 // curl -d '{"addresses": ["bchtest:qzjtnzcvzxx7s0na88yrg3zl28wwvfp97538sgrrmr", "bchtest:qp6hgvevf4gzz6l7pgcte3gaaud9km0l459fa23dul"], "from": 1, "to": 5}' -H "Content-Type: application/json" http://localhost:3000/v2/address/details
-async function details(req, res, next) {
+async function details(
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) {
   try {
     const addresses = req.body.addresses
 
@@ -112,20 +132,28 @@ async function details(req, res, next) {
     // Return the array of retrieved address information.
     res.status(200)
     return res.json(retArray)
-  } catch (error) {
-    // Write out error to error log.
-    //logger.error(`Error in address/details: `, error)
+  } catch (err) {
+    // Attempt to decode the error message.
+    const { msg, status } = routeUtils.decodeError(err)
+    if (msg) {
+      res.status(status)
+      return res.json({ error: msg })
+    }
 
-    // Return error message to the caller.
+    // Write out error to error log.
+    //logger.error(`Error in rawtransactions/decodeRawTransaction: `, err)
+
     res.status(500)
-    if (error.response && error.response.data && error.response.data.error)
-      return res.json({ error: error.response.data.error })
-    return res.json({ error: util.inspect(error) })
+    return res.json({ error: util.inspect(err) })
   }
 }
 
 // Retrieve UTXO information for an address.
-async function utxo(req, res, next) {
+async function utxo(
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) {
   try {
     const addresses = req.body.addresses
 
@@ -178,19 +206,27 @@ async function utxo(req, res, next) {
     res.status(200)
     return res.json(retArray)
   } catch (err) {
-    // Write out error to error log.
-    //logger.error(`Error in address/details: `, error)
+    // Attempt to decode the error message.
+    const { msg, status } = routeUtils.decodeError(err)
+    if (msg) {
+      res.status(status)
+      return res.json({ error: msg })
+    }
 
-    // Return error message to the caller.
+    // Write out error to error log.
+    //logger.error(`Error in rawtransactions/decodeRawTransaction: `, err)
+
     res.status(500)
-    if (error.response && error.response.data && error.response.data.error)
-      return res.json({ error: error.response.data.error })
-    return res.json({ error: util.inspect(error) })
+    return res.json({ error: util.inspect(err) })
   }
 }
 
 // Retrieve any unconfirmed TX information for a given address.
-async function unconfirmed(req, res, next) {
+async function unconfirmed(
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) {
   try {
     const addresses = req.body.addresses
 
@@ -249,19 +285,27 @@ async function unconfirmed(req, res, next) {
     res.status(200)
     return res.json(retArray)
   } catch (err) {
-    // Write out error to error log.
-    //logger.error(`Error in address/details: `, error)
+    // Attempt to decode the error message.
+    const { msg, status } = routeUtils.decodeError(err)
+    if (msg) {
+      res.status(status)
+      return res.json({ error: msg })
+    }
 
-    // Return error message to the caller.
+    // Write out error to error log.
+    //logger.error(`Error in rawtransactions/decodeRawTransaction: `, err)
+
     res.status(500)
-    if (error.response && error.response.data && error.response.data.error)
-      return res.json({ error: error.response.data.error })
-    return res.json({ error: util.inspect(error) })
+    return res.json({ error: util.inspect(err) })
   }
 }
 
 // Get an array of TX information for a given address.
-async function transactions(req, res, next) {
+async function transactions(
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) {
   try {
     const addresses = req.body.addresses
 
@@ -316,14 +360,18 @@ async function transactions(req, res, next) {
     res.status(200)
     return res.json(retArray)
   } catch (err) {
-    // Write out error to error log.
-    //logger.error(`Error in address/details: `, error)
+    // Attempt to decode the error message.
+    const { msg, status } = routeUtils.decodeError(err)
+    if (msg) {
+      res.status(status)
+      return res.json({ error: msg })
+    }
 
-    // Return error message to the caller.
+    // Write out error to error log.
+    //logger.error(`Error in rawtransactions/decodeRawTransaction: `, err)
+
     res.status(500)
-    if (error.response && error.response.data && error.response.data.error)
-      return res.json({ error: error.response.data.error })
-    return res.json({ error: util.inspect(error) })
+    return res.json({ error: util.inspect(err) })
   }
 }
 

--- a/src/routes/v2/address.ts
+++ b/src/routes/v2/address.ts
@@ -673,18 +673,7 @@ async function transactionsSingle(
         error: `Invalid network. Trying to use a testnet address on mainnet, or vice versa.`
       })
     }
-/*
-    interface Iutxo {
-      address: String
-      txid: String
-      vout: Number,
-      scriptPubKey: String
-      amount: Number,
-      satoshis: Number,
-      height: Number,
-      confirmations: Number
-    }
-*/
+
     // Query the Insight API.
     const retData = await transactionsFromInsight(address)
     //console.log(`retData: ${JSON.stringify(retData,null,2)}`)

--- a/src/routes/v2/address.ts
+++ b/src/routes/v2/address.ts
@@ -60,7 +60,8 @@ router.post("/utxo", config.addressRateLimit3, utxoBulk)
 router.get("/utxo/:address", config.addressRateLimit3, utxoSingle)
 router.post("/unconfirmed", config.addressRateLimit4, unconfirmedBulk)
 router.get("/unconfirmed/:address", config.addressRateLimit4, unconfirmedSingle)
-router.post("/transactions/:address", config.addressRateLimit5, transactions)
+router.post("/transactions", config.addressRateLimit5, transactionsBulk)
+//router.get("/transactions/:address", config.addressRateLimit5, transactionsSingle)
 
 // Root API endpoint. Simply acknowledges that it exists.
 function root(
@@ -546,7 +547,7 @@ async function unconfirmedSingle(
 }
 
 // Get an array of TX information for a given address.
-async function transactions(
+async function transactionsBulk(
   req: express.Request,
   res: express.Response,
   next: express.NextFunction
@@ -630,6 +631,6 @@ module.exports = {
     utxoSingle,
     unconfirmedBulk,
     unconfirmedSingle,
-    transactions
+    transactionsBulk
   }
 }

--- a/src/routes/v2/transaction.ts
+++ b/src/routes/v2/transaction.ts
@@ -25,6 +25,7 @@ const config: IRLConfig = {
   transactionRateLimit2: undefined
 }
 
+// Manipulates and formats the raw data comming from Insight API.
 const processInputs = (tx: any) => {
   if (tx.vin) {
     tx.vin.forEach((vin: any) => {
@@ -61,7 +62,8 @@ while (i < 3) {
 }
 
 router.get("/", config.transactionRateLimit1, root)
-router.post("/details", config.transactionRateLimit1, details)
+router.post("/details", config.transactionRateLimit1, detailsBulk)
+//router.get("/details/:txid", config.transactionRateLimit1, detailsSingle)
 
 function root(
   req: express.Request,
@@ -71,7 +73,25 @@ function root(
   return res.json({ status: "transaction" })
 }
 
-async function details(
+// Retrieve transaction data from the Insight API
+async function transactionsFromInsight(txid: string) {
+  try {
+    let path = `${process.env.BITCOINCOM_BASEURL}tx/${txid}`
+
+    // Query the Insight server.
+    const response = await axios.get(path)
+
+    // Parse the data.
+    const parsed = response.data
+    if (parsed) processInputs(parsed)
+
+    return parsed
+  } catch (err) {
+    throw err
+  }
+}
+
+async function detailsBulk(
   req: express.Request,
   res: express.Response,
   next: express.NextFunction
@@ -92,14 +112,7 @@ async function details(
     for (let i = 0; i < txids.length; i++) {
       const thisTxid = txids[i] // Current address.
 
-      //let path = `${process.env.BITCOINCOM_BASEURL}addr/${legacyAddr}`
-      let path = `${process.env.BITCOINCOM_BASEURL}tx/${thisTxid}`
-
-      // Query the Insight server.
-      const response = await axios.get(path)
-
-      const parsed = response.data
-      if (parsed) processInputs(parsed)
+      const parsed = await transactionsFromInsight(thisTxid)
 
       retArray.push(parsed)
     }
@@ -125,6 +138,7 @@ module.exports = {
   router,
   testableComponents: {
     root,
-    details
+    detailsBulk,
+    //detailsSingle
   }
 }

--- a/test/v2/address.js
+++ b/test/v2/address.js
@@ -326,14 +326,14 @@ describe("#AddressRouter", () => {
     })
   })
 
-  describe("#AddressUtxo", () => {
+  describe("#AddressUtxoBulk", () => {
     // utxo route handler.
-    const utxo = addressRoute.testableComponents.utxo
+    const utxoBulk = addressRoute.testableComponents.utxoBulk
 
     it("should throw an error for an empty body", async () => {
       req.body = {}
 
-      const result = await utxo(req, res)
+      const result = await utxoBulk(req, res)
 
       assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
       assert.include(
@@ -348,7 +348,7 @@ describe("#AddressRouter", () => {
         address: `qzs02v05l7qs5s24srqju498qu55dwuj0cx5ehjm2c`
       }
 
-      const result = await utxo(req, res)
+      const result = await utxoBulk(req, res)
 
       assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
       assert.include(
@@ -363,7 +363,7 @@ describe("#AddressRouter", () => {
         addresses: [`02v05l7qs5s24srqju498qu55dwuj0cx5ehjm2c`]
       }
 
-      const result = await utxo(req, res)
+      const result = await utxoBulk(req, res)
 
       assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
       assert.include(
@@ -378,7 +378,7 @@ describe("#AddressRouter", () => {
         addresses: [`bitcoincash:qqqvv56zepke5k0xeaehlmjtmkv9ly2uzgkxpajdx3`]
       }
 
-      const result = await utxo(req, res)
+      const result = await utxoBulk(req, res)
 
       assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
       assert.include(result.error, "Invalid network", "Proper error message")
@@ -395,7 +395,7 @@ describe("#AddressRouter", () => {
         // Switch the Insight URL to something that will error out.
         process.env.BITCOINCOM_BASEURL = "http://fakeurl/api"
 
-        const result = await utxo(req, res)
+        const result = await utxoBulk(req, res)
 
         // Restore the saved URL.
         process.env.BITCOINCOM_BASEURL = savedUrl
@@ -421,22 +421,25 @@ describe("#AddressRouter", () => {
       }
 
       // Call the details API.
-      const result = await utxo(req, res)
+      const result = await utxoBulk(req, res)
+      //console.log(`result: ${util.inspect(result)}`)
 
-      // Assert that required fields exist in the returned object.
-      const firstResult = result[0][0]
+      assert.isArray(result, "result should be an array")
 
-      assert.isArray(result[0], "result should be an array")
+      // Each element should have these primary properties.
+      assert.hasAllKeys(result[0], ["utxos", "legacyAddress", "cashAddress"])
 
-      // Validate data structure.
-      assert.exists(firstResult.address)
-      assert.exists(firstResult.txid)
-      assert.exists(firstResult.vout)
-      assert.exists(firstResult.scriptPubKey)
-      assert.exists(firstResult.amount)
-      assert.exists(firstResult.satoshis)
-      assert.exists(firstResult.height)
-      assert.exists(firstResult.confirmations)
+      // Validate the UTXO data structure.
+      assert.hasAnyKeys(result[0].utxos[0], [
+        "address",
+        "txid",
+        "vout",
+        "scriptPubKey",
+        "amount",
+        "satoshis",
+        "height",
+        "confirmations"
+      ])
     })
 
     it("should get utxos for mulitple addresses", async () => {
@@ -459,10 +462,111 @@ describe("#AddressRouter", () => {
       }
 
       // Call the details API.
-      const result = await utxo(req, res)
+      const result = await utxoBulk(req, res)
+      //console.log(`result: ${util.inspect(result)}`)
 
       assert.isArray(result)
       assert.equal(result.length, 2, "2 outputs for 2 inputs")
+    })
+  })
+
+  describe("#AddressUtxoSingle", () => {
+    // details route handler.
+    const utxoSingle = addressRoute.testableComponents.utxoSingle
+
+    it("should throw 400 if address is empty", async () => {
+      const result = await utxoSingle(req, res)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      assert.hasAllKeys(result, ["error"])
+      assert.include(result.error, "address can not be empty")
+    })
+
+    it("should error on an array", async () => {
+      req.params.address = [`qzs02v05l7qs5s24srqju498qu55dwuj0cx5ehjm2c`]
+
+      const result = await utxoSingle(req, res)
+
+      assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
+      assert.include(
+        result.error,
+        "address can not be an array",
+        "Proper error message"
+      )
+    })
+
+    it("should throw an error for an invalid address", async () => {
+      req.params.address = `02v05l7qs5s24srqju498qu55dwuj0cx5ehjm2c`
+
+      const result = await utxoSingle(req, res)
+
+      assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
+      assert.include(
+        result.error,
+        "Invalid BCH address",
+        "Proper error message"
+      )
+    })
+
+    it("should detect a network mismatch", async () => {
+      req.params.address = `bitcoincash:qqqvv56zepke5k0xeaehlmjtmkv9ly2uzgkxpajdx3`
+
+      const result = await utxoSingle(req, res)
+
+      assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
+      assert.include(result.error, "Invalid network", "Proper error message")
+    })
+
+    it("should throw 500 when network issues", async () => {
+      const savedUrl = process.env.BITCOINCOM_BASEURL
+
+      try {
+        req.params.address = `qzs02v05l7qs5s24srqju498qu55dwuj0cx5ehjm2c`
+
+        // Switch the Insight URL to something that will error out.
+        process.env.BITCOINCOM_BASEURL = "http://fakeurl/api/"
+
+        const result = await utxoSingle(req, res)
+
+        // Restore the saved URL.
+        process.env.BITCOINCOM_BASEURL = savedUrl
+
+        assert.equal(res.statusCode, 500, "HTTP status code 500 expected.")
+        assert.include(result.error, "ENOTFOUND", "Error message expected")
+      } catch (err) {
+        // Restore the saved URL.
+        process.env.BITCOINCOM_BASEURL = savedUrl
+      }
+    })
+
+    it("should get details for a single address", async () => {
+      req.params.address = `bchtest:qq89kjkeqz9mngp8kl3dpmu43y2wztdjqu500gn4c4`
+
+      // Mock the Insight URL for unit tests.
+      if (process.env.TEST === "unit") {
+        nock(`${process.env.BITCOINCOM_BASEURL}`)
+          .get(`/addr/mgps7qxk2Z5ma4mXsviznnet8wx4VvMPFz/utxo`)
+          .reply(200, mockData.mockUtxoDetails)
+      }
+
+      // Call the details API.
+      const result = await utxoSingle(req, res)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      // Each element should have these primary properties.
+      assert.hasAllKeys(result, ["utxos", "legacyAddress", "cashAddress"])
+
+      // Validate the UTXO data structure.
+      assert.hasAnyKeys(result.utxos[0], [
+        "address",
+        "txid",
+        "vout",
+        "scriptPubKey",
+        "amount",
+        "satoshis",
+        "height",
+        "confirmations"
+      ])
     })
   })
 

--- a/test/v2/address.js
+++ b/test/v2/address.js
@@ -8,7 +8,7 @@
   To-Do:
   -/details/:address
   --Verify to/from query options work correctly.
-  -/unconfirmed/:address
+  -GET /unconfirmed/:address & POST /unconfirmed
   --Should initiate a transfer of BCH to verify unconfirmed TX.
   ---This would be more of an e2e test.
 */
@@ -570,14 +570,14 @@ describe("#AddressRouter", () => {
     })
   })
 
-  describe("#AddressUnconfirmed", () => {
+  describe("#AddressUnconfirmedBulk", () => {
     // unconfirmed route handler.
-    const unconfirmed = addressRoute.testableComponents.unconfirmed
+    const unconfirmedBulk = addressRoute.testableComponents.unconfirmedBulk
 
     it("should throw an error for an empty body", async () => {
       req.body = {}
 
-      const result = await unconfirmed(req, res)
+      const result = await unconfirmedBulk(req, res)
 
       assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
       assert.include(
@@ -592,7 +592,7 @@ describe("#AddressRouter", () => {
         address: `bchtest:qq89kjkeqz9mngp8kl3dpmu43y2wztdjqu500gn4c4`
       }
 
-      const result = await unconfirmed(req, res)
+      const result = await unconfirmedBulk(req, res)
 
       assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
       assert.include(
@@ -607,7 +607,7 @@ describe("#AddressRouter", () => {
         addresses: [`02v05l7qs5s24srqju498qu55dwuj0cx5ehjm2c`]
       }
 
-      const result = await unconfirmed(req, res)
+      const result = await unconfirmedBulk(req, res)
 
       assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
       assert.include(
@@ -622,7 +622,7 @@ describe("#AddressRouter", () => {
         addresses: [`bitcoincash:qqqvv56zepke5k0xeaehlmjtmkv9ly2uzgkxpajdx3`]
       }
 
-      const result = await unconfirmed(req, res)
+      const result = await unconfirmedBulk(req, res)
 
       assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
       assert.include(result.error, "Invalid network", "Proper error message")
@@ -639,7 +639,7 @@ describe("#AddressRouter", () => {
         // Switch the Insight URL to something that will error out.
         process.env.BITCOINCOM_BASEURL = "http://fakeurl/api"
 
-        const result = await unconfirmed(req, res)
+        const result = await unconfirmedBulk(req, res)
 
         // Restore the saved URL.
         process.env.BITCOINCOM_BASEURL = savedUrl
@@ -665,7 +665,7 @@ describe("#AddressRouter", () => {
       }
 
       // Call the details API.
-      const result = await unconfirmed(req, res)
+      const result = await unconfirmedBulk(req, res)
       //console.log(`result: ${util.inspect(result)}`)
 
       assert.isArray(result, "result should be an array")
@@ -695,9 +695,99 @@ describe("#AddressRouter", () => {
       }
 
       // Call the details API.
-      const result = await unconfirmed(req, res)
+      const result = await unconfirmedBulk(req, res)
 
       assert.isArray(result)
+    })
+  })
+
+  describe("#AddressUnconfirmedSingle", () => {
+    // details route handler.
+    const unconfirmedSingle = addressRoute.testableComponents.unconfirmedSingle
+
+    it("should throw 400 if address is empty", async () => {
+      const result = await unconfirmedSingle(req, res)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      assert.hasAllKeys(result, ["error"])
+      assert.include(result.error, "address can not be empty")
+    })
+
+    it("should error on an array", async () => {
+      req.params.address = [`qzs02v05l7qs5s24srqju498qu55dwuj0cx5ehjm2c`]
+
+      const result = await unconfirmedSingle(req, res)
+
+      assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
+      assert.include(
+        result.error,
+        "address can not be an array",
+        "Proper error message"
+      )
+    })
+
+    it("should throw an error for an invalid address", async () => {
+      req.params.address = `02v05l7qs5s24srqju498qu55dwuj0cx5ehjm2c`
+
+      const result = await unconfirmedSingle(req, res)
+
+      assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
+      assert.include(
+        result.error,
+        "Invalid BCH address",
+        "Proper error message"
+      )
+    })
+
+    it("should detect a network mismatch", async () => {
+      req.params.address = `bitcoincash:qqqvv56zepke5k0xeaehlmjtmkv9ly2uzgkxpajdx3`
+
+      const result = await unconfirmedSingle(req, res)
+
+      assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
+      assert.include(result.error, "Invalid network", "Proper error message")
+    })
+
+    it("should throw 500 when network issues", async () => {
+      const savedUrl = process.env.BITCOINCOM_BASEURL
+
+      try {
+        req.params.address = `qzs02v05l7qs5s24srqju498qu55dwuj0cx5ehjm2c`
+
+        // Switch the Insight URL to something that will error out.
+        process.env.BITCOINCOM_BASEURL = "http://fakeurl/api/"
+
+        const result = await unconfirmedSingle(req, res)
+
+        // Restore the saved URL.
+        process.env.BITCOINCOM_BASEURL = savedUrl
+
+        assert.equal(res.statusCode, 500, "HTTP status code 500 expected.")
+        assert.include(result.error, "ENOTFOUND", "Error message expected")
+      } catch (err) {
+        // Restore the saved URL.
+        process.env.BITCOINCOM_BASEURL = savedUrl
+      }
+    })
+
+    it("should get details for a single address", async () => {
+      req.params.address = `bchtest:qq89kjkeqz9mngp8kl3dpmu43y2wztdjqu500gn4c4`
+
+      // Mock the Insight URL for unit tests.
+      if (process.env.TEST === "unit") {
+        nock(`${process.env.BITCOINCOM_BASEURL}`)
+          .get(`/addr/mgps7qxk2Z5ma4mXsviznnet8wx4VvMPFz/utxo`)
+          .reply(200, mockData.mockUtxoDetails)
+      }
+
+      // Call the details API.
+      const result = await unconfirmedSingle(req, res)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      // Each element should have these primary properties.
+      assert.hasAllKeys(result, ["utxos", "legacyAddress", "cashAddress"])
+
+      assert.isArray(result.utxos)
     })
   })
 

--- a/test/v2/address.js
+++ b/test/v2/address.js
@@ -791,14 +791,14 @@ describe("#AddressRouter", () => {
     })
   })
 
-  describe("#AddressTransactions", () => {
+  describe("#AddressTransactionsBulk", () => {
     // unconfirmed route handler.
-    const transactions = addressRoute.testableComponents.transactions
+    const transactionsBulk = addressRoute.testableComponents.transactionsBulk
 
     it("should throw an error for an empty body", async () => {
       req.body = {}
 
-      const result = await transactions(req, res)
+      const result = await transactionsBulk(req, res)
 
       assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
       assert.include(
@@ -813,7 +813,7 @@ describe("#AddressRouter", () => {
         address: `qzs02v05l7qs5s24srqju498qu55dwuj0cx5ehjm2c`
       }
 
-      const result = await transactions(req, res)
+      const result = await transactionsBulk(req, res)
 
       assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
       assert.include(
@@ -828,7 +828,7 @@ describe("#AddressRouter", () => {
         addresses: [`02v05l7qs5s24srqju498qu55dwuj0cx5ehjm2c`]
       }
 
-      const result = await transactions(req, res)
+      const result = await transactionsBulk(req, res)
 
       assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
       assert.include(
@@ -843,7 +843,7 @@ describe("#AddressRouter", () => {
         addresses: [`bitcoincash:qqqvv56zepke5k0xeaehlmjtmkv9ly2uzgkxpajdx3`]
       }
 
-      const result = await transactions(req, res)
+      const result = await transactionsBulk(req, res)
 
       assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
       assert.include(result.error, "Invalid network", "Proper error message")
@@ -860,7 +860,7 @@ describe("#AddressRouter", () => {
         // Switch the Insight URL to something that will error out.
         process.env.BITCOINCOM_BASEURL = "http://fakeurl/api"
 
-        const result = await transactions(req, res)
+        const result = await transactionsBulk(req, res)
 
         // Restore the saved URL.
         process.env.BITCOINCOM_BASEURL = savedUrl
@@ -888,7 +888,7 @@ describe("#AddressRouter", () => {
       }
 
       // Call the details API.
-      const result = await transactions(req, res)
+      const result = await transactionsBulk(req, res)
 
       assert.isArray(result, "result should be an array")
 
@@ -923,7 +923,7 @@ describe("#AddressRouter", () => {
       }
 
       // Call the details API.
-      const result = await transactions(req, res)
+      const result = await transactionsBulk(req, res)
 
       assert.isArray(result, "result should be an array")
 

--- a/test/v2/transaction.js
+++ b/test/v2/transaction.js
@@ -86,13 +86,13 @@ describe("#Transactions", () => {
     })
   })
 
-  describe("#details", async () => {
-    const details = transactionRoute.testableComponents.details
+  describe("#detailsBulk", async () => {
+    const detailsBulk = transactionRoute.testableComponents.detailsBulk
 
     it("should throw an error for an empty body", async () => {
       req.body = {}
 
-      const result = await details(req, res)
+      const result = await detailsBulk(req, res)
 
       assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
       assert.include(
@@ -107,7 +107,7 @@ describe("#Transactions", () => {
         txids: `6f235bd3a689f03c11969cd649ccad592462ca958bc519a30194e7a67b349a40`
       }
 
-      const result = await details(req, res)
+      const result = await detailsBulk(req, res)
 
       assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
       assert.include(
@@ -133,7 +133,7 @@ describe("#Transactions", () => {
         txids: [fakeTXID]
       }
 
-      const result = await details(req, res)
+      const result = await detailsBulk(req, res)
       //console.log(`result: ${util.inspect(result)}`)
 
       assert.equal(res.statusCode, 500, "HTTP status code 500 expected.")
@@ -153,7 +153,7 @@ describe("#Transactions", () => {
         txids: [txid]
       }
 
-      const result = await details(req, res)
+      const result = await detailsBulk(req, res)
       //console.log(`result: ${util.inspect(result)}`)
 
       assert.isArray(result)
@@ -197,7 +197,7 @@ describe("#Transactions", () => {
         txids: [txid1, txid2]
       }
 
-      const result = await details(req, res)
+      const result = await detailsBulk(req, res)
       //console.log(`result: ${util.inspect(result)}`)
 
       assert.isArray(result)

--- a/test/v2/transaction.js
+++ b/test/v2/transaction.js
@@ -4,6 +4,11 @@
   This test file uses the environment variable TEST to switch between unit
   and integration tests. By default, TEST is set to 'unit'. Set this variable
   to 'integration' to run the tests against BCH mainnet.
+
+  TODO:
+  -See "should throw an error for an invalid txid" for detailsSingle:
+  --The error handler should be refactored to return an intelligent error message,
+  instead of the 503 error it is returning now.
 */
 
 "use strict"
@@ -217,6 +222,108 @@ describe("#Transactions", () => {
         "valueIn",
         "fees"
       ])
+    })
+  })
+
+  describe("#detailsSingle", () => {
+    // details route handler.
+    const detailsSingle = transactionRoute.testableComponents.detailsSingle
+
+    it("should throw 400 if txid is empty", async () => {
+      const result = await detailsSingle(req, res)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      assert.hasAllKeys(result, ["error"])
+      assert.include(result.error, "txid can not be empty")
+    })
+
+    it("should error on an array", async () => {
+      req.params.txid = [`qzs02v05l7qs5s24srqju498qu55dwuj0cx5ehjm2c`]
+
+      const result = await detailsSingle(req, res)
+
+      assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
+      assert.include(
+        result.error,
+        "txid can not be an array",
+        "Proper error message"
+      )
+    })
+
+    it("should throw an error for an invalid txid", async () => {
+      if (process.env.TEST !== "unit") {
+        req.params.txid = `02v05l7qs5s24srqju498qu55dwuj0cx5ehjm2c`
+
+        const result = await detailsSingle(req, res)
+        //console.log(`result: ${util.inspect(result)}`)
+
+        // The error handling code should probably be updated to respond with a better
+        // error message.
+        assert.equal(res.statusCode, 500, "HTTP status code 500 expected.")
+        assert.include(
+          result.error,
+          "parameter 1 must be hexadecimal string",
+          "Proper error message"
+        )
+      }
+    })
+
+    it("should throw 500 when network issues", async () => {
+      const savedUrl = process.env.BITCOINCOM_BASEURL
+
+      try {
+        req.params.txid = `6f235bd3a689f03c11969cd649ccad592462ca958bc519a30194e7a67b349a40`
+
+        // Switch the Insight URL to something that will error out.
+        process.env.BITCOINCOM_BASEURL = "http://fakeurl/api/"
+
+        const result = await detailsSingle(req, res)
+
+        // Restore the saved URL.
+        process.env.BITCOINCOM_BASEURL = savedUrl
+
+        assert.equal(res.statusCode, 500, "HTTP status code 500 expected.")
+        assert.include(result.error, "ENOTFOUND", "Error message expected")
+      } catch (err) {
+        // Restore the saved URL.
+        process.env.BITCOINCOM_BASEURL = savedUrl
+      }
+    })
+
+    it("should get details for a single address", async () => {
+      const txid = `6f235bd3a689f03c11969cd649ccad592462ca958bc519a30194e7a67b349a40`
+      req.params.txid = txid
+
+      // Mock the Insight URL for unit tests.
+      if (process.env.TEST === "unit") {
+        nock(`${process.env.BITCOINCOM_BASEURL}`)
+          .get(`/tx/${txid}`)
+          .reply(200, mockData.mockDetails)
+      }
+
+      // Call the details API.
+      const result = await detailsSingle(req, res)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      // Assert that required fields exist in the returned object.
+      assert.hasAllKeys(result, [
+        "txid",
+        "version",
+        "locktime",
+        "vin",
+        "vout",
+        "blockhash",
+        "blockheight",
+        "confirmations",
+        "time",
+        "blocktime",
+        "valueOut",
+        "size",
+        "valueIn",
+        "fees"
+      ])
+      assert.isArray(result.vin)
+      assert.isArray(result.vout)
     })
   })
 })


### PR DESCRIPTION
After discussing the pros and cons and length, @SpendBCH and I decided that the best past forward for the V2 refactor is to keep the GET endpoints for Insight API calls, but restrict them to single item calls (address, utxo, tx, etc). This maintains the nice swagger UI, URL execution in a browser, and 'friendly' looking endpoint.

The new POST endpoints are maintained. It's still possible to make the call with 1 to 20 elements, but the inputs must be in the *body* (vs the GET parameters), and the input must be an array.

The outputs are also different. GET calls return a single item, whereas POST calls will return an array of items.