### PR TITLE
Fixing gettxout integration tests

### DIFF
--- a/test/v2/blockchain.js
+++ b/test/v2/blockchain.js
@@ -4,8 +4,6 @@
   --Add tests for 'verbos' input values
   -getMempoolEntry
   --Needs e2e test to create unconfirmed tx, for real-world test.
-  -getTxOut
-  --Needs an e2e test to create an unconfirmed TX, for a 'integration' test.
 */
 
 "use strict"
@@ -586,38 +584,36 @@ describe("#BlockchainRouter", () => {
     })
 
     // This test can only run for unit tests. See TODO at the top of this file.
-    if (process.env.TEST === "unit") {
-      it("should GET /getTxOut", async () => {
-        // Mock the RPC call for unit tests.
-        if (process.env.TEST === "unit") {
-          nock(`${process.env.RPC_BASEURL}`)
-            .post(``)
-            .reply(200, { result: mockData.mockTxOut })
-        }
+    it("should GET /getTxOut", async () => {
+      // Mock the RPC call for unit tests.
+      if (process.env.TEST === "unit") {
+        nock(`${process.env.RPC_BASEURL}`)
+          .post(``)
+          .reply(200, { result: mockData.mockTxOut })
+      }
 
-        req.params.txid = `d65881582ff2bff36747d7a0d0e273f10281abc8bd5c15df5d72f8f3fa779cde`
-        req.params.n = 0
+      req.params.txid = `5747e6462e2c452a5d583fd6a5f82866cd8e4a86826c86d9a1842b7d023e0c0c`
+      req.params.n = 0
 
-        const result = await getTxOut(req, res)
-        //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+      const result = await getTxOut(req, res)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
-        assert.hasAllKeys(result, [
-          "bestblock",
-          "confirmations",
-          "value",
-          "scriptPubKey",
-          "coinbase"
-        ])
-        assert.hasAllKeys(result.scriptPubKey, [
-          "asm",
-          "hex",
-          "reqSigs",
-          "type",
-          "addresses"
-        ])
-        assert.isArray(result.scriptPubKey.addresses)
-      })
-    }
+      assert.hasAllKeys(result, [
+        "bestblock",
+        "confirmations",
+        "value",
+        "scriptPubKey",
+        "coinbase"
+      ])
+      assert.hasAllKeys(result.scriptPubKey, [
+        "asm",
+        "hex",
+        "reqSigs",
+        "type",
+        "addresses"
+      ])
+      assert.isArray(result.scriptPubKey.addresses)
+    })
   })
 
   describe("getTxOutProof()", () => {

--- a/test/v2/blockchain.js
+++ b/test/v2/blockchain.js
@@ -4,6 +4,8 @@
   --Add tests for 'verbos' input values
   -getMempoolEntry
   --Needs e2e test to create unconfirmed tx, for real-world test.
+  -getTxOut
+  --Needs an e2e test to create an unconfirmed TX, for a 'integration' test.
 */
 
 "use strict"
@@ -583,36 +585,39 @@ describe("#BlockchainRouter", () => {
       )
     })
 
-    it("should GET /getTxOut", async () => {
-      // Mock the RPC call for unit tests.
-      if (process.env.TEST === "unit") {
-        nock(`${process.env.RPC_BASEURL}`)
-          .post(``)
-          .reply(200, { result: mockData.mockTxOut })
-      }
+    // This test can only run for unit tests. See TODO at the top of this file.
+    if (process.env.TEST === "unit") {
+      it("should GET /getTxOut", async () => {
+        // Mock the RPC call for unit tests.
+        if (process.env.TEST === "unit") {
+          nock(`${process.env.RPC_BASEURL}`)
+            .post(``)
+            .reply(200, { result: mockData.mockTxOut })
+        }
 
-      req.params.txid = `d65881582ff2bff36747d7a0d0e273f10281abc8bd5c15df5d72f8f3fa779cde`
-      req.params.n = 0
+        req.params.txid = `d65881582ff2bff36747d7a0d0e273f10281abc8bd5c15df5d72f8f3fa779cde`
+        req.params.n = 0
 
-      const result = await getTxOut(req, res)
-      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+        const result = await getTxOut(req, res)
+        //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
-      assert.hasAllKeys(result, [
-        "bestblock",
-        "confirmations",
-        "value",
-        "scriptPubKey",
-        "coinbase"
-      ])
-      assert.hasAllKeys(result.scriptPubKey, [
-        "asm",
-        "hex",
-        "reqSigs",
-        "type",
-        "addresses"
-      ])
-      assert.isArray(result.scriptPubKey.addresses)
-    })
+        assert.hasAllKeys(result, [
+          "bestblock",
+          "confirmations",
+          "value",
+          "scriptPubKey",
+          "coinbase"
+        ])
+        assert.hasAllKeys(result.scriptPubKey, [
+          "asm",
+          "hex",
+          "reqSigs",
+          "type",
+          "addresses"
+        ])
+        assert.isArray(result.scriptPubKey.addresses)
+      })
+    }
   })
 
   describe("getTxOutProof()", () => {


### PR DESCRIPTION
This PR fixes the failing integration test for the `blockchain/gettxout()` endpoint. The reason the test was failing is because something happened to the UTXO attached to the TXID that was originally used. I fixed it by creating a new wallet and sending some tBCH to in from the faucet. I then destroyed the wallet so that the UTXO will never change.