### PR TITLE
fix(restv2): expose raw transaction endpoints in swagger.

### DIFF
--- a/dist/public/bitcoin-com-mainnet-rest-v2.json
+++ b/dist/public/bitcoin-com-mainnet-rest-v2.json
@@ -2571,6 +2571,303 @@
 				}
 			}
 		},
+		"/rawtransactions/sendRawTransaction/{hex}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "Submits raw transaction to local node and network.",
+				"description": "Submits raw transaction (serialized, hex-encoded) to local node and network. Also see createrawtransaction and signrawtransaction calls.",
+				"operationId": "sendRawTransaction",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "hex",
+						"description": "The hex string of the raw transaction",
+						"required": true,
+						"example": "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac00000000",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful operation"
+					},
+					"400": {
+						"description": "Transaction not found"
+					}
+				}
+			}
+		},
+		"/rawtransactions/create/{inputs}/{outputs}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "createRawTxChange",
+				"description": "Create a transaction spending the given inputs and creating new outputs. API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+				"operationId": "rawTransactionsCreate",
+				"parameters": [
+					{
+						"name": "inputs",
+						"in": "path",
+						"description": "A json array of json objects",
+						"required": true,
+						"example": "[{\"txid\":\"myid\",\"vout\":0}]",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "outputs",
+						"in": "path",
+						"description": "A json object with outputs",
+						"required": true,
+						"example": "{}",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "locktime",
+						"in": "query",
+						"description": "Raw locktime. Non-0 value also locktime-activates inputs",
+						"required": false,
+						"example": 0,
+						"schema": {
+							"type": "number"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful response"
+					},
+					"400": {
+						"description": "Received an invalid block height.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"status": 500,
+									"message": "Received an invalid block height."
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/rawtransactions/change/{rawTx}/{prevTxs}/{destination}/{fee}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "createRawTxChange",
+				"description": "Adds a change output to the transaction.API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+				"operationId": "rawTransactionsChange",
+				"parameters": [
+					{
+						"name": "rawTx",
+						"in": "path",
+						"description": "The raw transaction to extend",
+						"required": true,
+						"example": "0100000001b15ee60431ef57ec682790dec5a3c0d83a0c360633ea8308fbf6d5fc10a779670400000000ffffffff025c0d00000000000047512102f3e471222bb57a7d416c82bf81c627bfcd2bdc47f36e763ae69935bba4601ece21021580b888ff56feb27f17f08802ebed26258c23697d6a462d43fc13b565fda2dd52aeaa0a0000000000001976a914946cb2e08075bcbaf157e47bcb67eb2b2339d24288ac00000000",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "prevTxs",
+						"in": "path",
+						"description": "A JSON array of transaction inputs",
+						"required": true,
+						"example": "[{\"txid\":\"6779a710fcd5f6fb0883ea3306360c3ad8c0a3c5de902768ec57ef3104e65eb1\",\"vout\":4,\"scriptPubKey\":\"76a9147b25205fd98d462880a3e5b0541235831ae959e588ac\",\"value\":0.00068257}]",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "destination",
+						"in": "path",
+						"description": "The destination for the change",
+						"required": true,
+						"example": "bchtest:qq2j9gp97gm9a6lwvhxc4zu28qvqm0x4j5e72v7ejg",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "fee",
+						"in": "path",
+						"description": "The desired transaction fees",
+						"required": true,
+						"example": 0.000035,
+						"schema": {
+							"type": "number"
+						}
+					},
+					{
+						"name": "position",
+						"in": "query",
+						"description": "The position of the change output (default: first position)",
+						"required": false,
+						"example": 1,
+						"schema": {
+							"type": "number"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful response"
+					},
+					"400": {
+						"description": "Received an invalid block height.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"status": 500,
+									"message": "Received an invalid block height."
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/rawtransactions/input/{rawTx}/{txid}/{n}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "createRawTxInput",
+				"description": "Adds a transaction input to the transaction.API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+				"operationId": "rawTransactionsInput",
+				"parameters": [
+					{
+						"name": "rawTx",
+						"in": "path",
+						"description": "The raw transaction to extend",
+						"required": true,
+						"example": "01000000000000000000",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "txid",
+						"in": "path",
+						"description": "The hash of the input transaction",
+						"required": true,
+						"example": "b006729017df05eda586df9ad3f8ccfee5be340aadf88155b784d1fc0e8342ee",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "n",
+						"in": "path",
+						"description": "The index of the transaction output used as input",
+						"required": true,
+						"example": 0,
+						"schema": {
+							"type": "number"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful response"
+					}
+				}
+			}
+		},
+		"/rawtransactions/opReturn/{rawTx}/{payload}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "createRawTxOpReturn",
+				"description": "Adds a payload with class C (op-return) encoding to the transaction.API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+				"operationId": "rawTransactionsOpReturn",
+				"parameters": [
+					{
+						"name": "rawTx",
+						"in": "path",
+						"description": "The raw transaction to extend",
+						"required": true,
+						"example": "01000000000000000000",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "payload",
+						"in": "path",
+						"description": "The hex-encoded payload to add",
+						"required": true,
+						"example": "00000000000000020000000006dac2c0",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful response"
+					}
+				}
+			}
+		},
+		"/rawtransactions/reference/{rawTx}/{destination}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "createRawTxReference",
+				"description": "Adds a reference output to the transaction. API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+				"operationId": "rawTransactionsReference",
+				"parameters": [
+					{
+						"name": "rawTx",
+						"in": "path",
+						"description": "The raw transaction to extend",
+						"required": true,
+						"example": "0100000001a7a9402ecd77f3c9f745793c9ec805bfa2e14b89877581c734c774864247e6f50400000000ffffffff03aa0a0000000000001976a9146d18edfe073d53f84dd491dae1379f8fb0dfe5d488ac5c0d0000000000004751210252ce4bdd3ce38b4ebbc5a6e1343608230da508ff12d23d85b58c964204c4cef3210294cc195fc096f87d0f813a337ae7e5f961b1c8a18f1f8604a909b3a5121f065b52aeaa0a0000000000001976a914946cb2e08075bcbaf157e47bcb67eb2b2339d24288ac00000000",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "destination",
+						"in": "path",
+						"description": "The reference address or destination",
+						"required": true,
+						"example": "bchtest:qq2j9gp97gm9a6lwvhxc4zu28qvqm0x4j5e72v7ejg",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "amount",
+						"in": "query",
+						"description": "The optional reference amount (minimal by default)",
+						"required": false,
+						"example": 0.005,
+						"schema": {
+							"type": "number"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful response"
+					}
+				}
+			}
+		},
 		"/transaction/details/{txid}": {
 			"get": {
 				"tags": [

--- a/dist/public/bitcoin-com-testnet-rest-v2.json
+++ b/dist/public/bitcoin-com-testnet-rest-v2.json
@@ -2571,6 +2571,303 @@
 				}
 			}
 		},
+		"/rawtransactions/sendRawTransaction/{hex}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "Submits raw transaction to local node and network.",
+				"description": "Submits raw transaction (serialized, hex-encoded) to local node and network. Also see createrawtransaction and signrawtransaction calls.",
+				"operationId": "sendRawTransaction",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "hex",
+						"description": "The hex string of the raw transaction",
+						"required": true,
+						"example": "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac00000000",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful operation"
+					},
+					"400": {
+						"description": "Transaction not found"
+					}
+				}
+			}
+		},
+		"/rawtransactions/create/{inputs}/{outputs}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "createRawTxChange",
+				"description": "Create a transaction spending the given inputs and creating new outputs. API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+				"operationId": "rawTransactionsCreate",
+				"parameters": [
+					{
+						"name": "inputs",
+						"in": "path",
+						"description": "A json array of json objects",
+						"required": true,
+						"example": "[{\"txid\":\"myid\",\"vout\":0}]",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "outputs",
+						"in": "path",
+						"description": "A json object with outputs",
+						"required": true,
+						"example": "{}",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "locktime",
+						"in": "query",
+						"description": "Raw locktime. Non-0 value also locktime-activates inputs",
+						"required": false,
+						"example": 0,
+						"schema": {
+							"type": "number"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful response"
+					},
+					"400": {
+						"description": "Received an invalid block height.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"status": 500,
+									"message": "Received an invalid block height."
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/rawtransactions/change/{rawTx}/{prevTxs}/{destination}/{fee}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "createRawTxChange",
+				"description": "Adds a change output to the transaction.API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+				"operationId": "rawTransactionsChange",
+				"parameters": [
+					{
+						"name": "rawTx",
+						"in": "path",
+						"description": "The raw transaction to extend",
+						"required": true,
+						"example": "0100000001b15ee60431ef57ec682790dec5a3c0d83a0c360633ea8308fbf6d5fc10a779670400000000ffffffff025c0d00000000000047512102f3e471222bb57a7d416c82bf81c627bfcd2bdc47f36e763ae69935bba4601ece21021580b888ff56feb27f17f08802ebed26258c23697d6a462d43fc13b565fda2dd52aeaa0a0000000000001976a914946cb2e08075bcbaf157e47bcb67eb2b2339d24288ac00000000",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "prevTxs",
+						"in": "path",
+						"description": "A JSON array of transaction inputs",
+						"required": true,
+						"example": "[{\"txid\":\"6779a710fcd5f6fb0883ea3306360c3ad8c0a3c5de902768ec57ef3104e65eb1\",\"vout\":4,\"scriptPubKey\":\"76a9147b25205fd98d462880a3e5b0541235831ae959e588ac\",\"value\":0.00068257}]",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "destination",
+						"in": "path",
+						"description": "The destination for the change",
+						"required": true,
+						"example": "bchtest:qq2j9gp97gm9a6lwvhxc4zu28qvqm0x4j5e72v7ejg",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "fee",
+						"in": "path",
+						"description": "The desired transaction fees",
+						"required": true,
+						"example": 0.000035,
+						"schema": {
+							"type": "number"
+						}
+					},
+					{
+						"name": "position",
+						"in": "query",
+						"description": "The position of the change output (default: first position)",
+						"required": false,
+						"example": 1,
+						"schema": {
+							"type": "number"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful response"
+					},
+					"400": {
+						"description": "Received an invalid block height.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"status": 500,
+									"message": "Received an invalid block height."
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/rawtransactions/input/{rawTx}/{txid}/{n}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "createRawTxInput",
+				"description": "Adds a transaction input to the transaction.API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+				"operationId": "rawTransactionsInput",
+				"parameters": [
+					{
+						"name": "rawTx",
+						"in": "path",
+						"description": "The raw transaction to extend",
+						"required": true,
+						"example": "01000000000000000000",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "txid",
+						"in": "path",
+						"description": "The hash of the input transaction",
+						"required": true,
+						"example": "b006729017df05eda586df9ad3f8ccfee5be340aadf88155b784d1fc0e8342ee",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "n",
+						"in": "path",
+						"description": "The index of the transaction output used as input",
+						"required": true,
+						"example": 0,
+						"schema": {
+							"type": "number"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful response"
+					}
+				}
+			}
+		},
+		"/rawtransactions/opReturn/{rawTx}/{payload}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "createRawTxOpReturn",
+				"description": "Adds a payload with class C (op-return) encoding to the transaction.API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+				"operationId": "rawTransactionsOpReturn",
+				"parameters": [
+					{
+						"name": "rawTx",
+						"in": "path",
+						"description": "The raw transaction to extend",
+						"required": true,
+						"example": "01000000000000000000",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "payload",
+						"in": "path",
+						"description": "The hex-encoded payload to add",
+						"required": true,
+						"example": "00000000000000020000000006dac2c0",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful response"
+					}
+				}
+			}
+		},
+		"/rawtransactions/reference/{rawTx}/{destination}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "createRawTxReference",
+				"description": "Adds a reference output to the transaction. API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+				"operationId": "rawTransactionsReference",
+				"parameters": [
+					{
+						"name": "rawTx",
+						"in": "path",
+						"description": "The raw transaction to extend",
+						"required": true,
+						"example": "0100000001a7a9402ecd77f3c9f745793c9ec805bfa2e14b89877581c734c774864247e6f50400000000ffffffff03aa0a0000000000001976a9146d18edfe073d53f84dd491dae1379f8fb0dfe5d488ac5c0d0000000000004751210252ce4bdd3ce38b4ebbc5a6e1343608230da508ff12d23d85b58c964204c4cef3210294cc195fc096f87d0f813a337ae7e5f961b1c8a18f1f8604a909b3a5121f065b52aeaa0a0000000000001976a914946cb2e08075bcbaf157e47bcb67eb2b2339d24288ac00000000",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "destination",
+						"in": "path",
+						"description": "The reference address or destination",
+						"required": true,
+						"example": "bchtest:qq2j9gp97gm9a6lwvhxc4zu28qvqm0x4j5e72v7ejg",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "amount",
+						"in": "query",
+						"description": "The optional reference amount (minimal by default)",
+						"required": false,
+						"example": 0.005,
+						"schema": {
+							"type": "number"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful response"
+					}
+				}
+			}
+		},
 		"/transaction/details/{txid}": {
 			"get": {
 				"tags": [

--- a/swaggerJSONFiles/paths.json
+++ b/swaggerJSONFiles/paths.json
@@ -1174,6 +1174,291 @@
         }
       }
     },
+    "/rawtransactions/sendRawTransaction/{hex}": {
+      "post": {
+        "tags": ["rawtransactions"],
+        "summary": "Submits raw transaction to local node and network.",
+        "description": "Submits raw transaction (serialized, hex-encoded) to local node and network. Also see createrawtransaction and signrawtransaction calls.",
+        "operationId": "sendRawTransaction",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "hex",
+            "description": "The hex string of the raw transaction",
+            "required": true,
+            "example": "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac00000000",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          },
+          "400": {
+            "description": "Transaction not found"
+          }
+        }
+      }
+    },
+    "/rawtransactions/create/{inputs}/{outputs}": {
+      "post": {
+        "tags": ["rawtransactions"],
+        "summary": "createRawTxChange",
+        "description": "Create a transaction spending the given inputs and creating new outputs. API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+        "operationId": "rawTransactionsCreate",
+        "parameters": [
+          {
+            "name": "inputs",
+            "in": "path",
+            "description": "A json array of json objects",
+            "required": true,
+            "example": "[{\"txid\":\"myid\",\"vout\":0}]",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "outputs",
+            "in": "path",
+            "description": "A json object with outputs",
+            "required": true,
+            "example": "{}",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "locktime",
+            "in": "query",
+            "description": "Raw locktime. Non-0 value also locktime-activates inputs",
+            "required": false,
+            "example": 0,
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful response"
+          },
+          "400": {
+            "description": "Received an invalid block height.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "status": 500,
+                  "message": "Received an invalid block height."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/rawtransactions/change/{rawTx}/{prevTxs}/{destination}/{fee}": {
+      "post": {
+        "tags": ["rawtransactions"],
+        "summary": "createRawTxChange",
+        "description": "Adds a change output to the transaction.API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+        "operationId": "rawTransactionsChange",
+        "parameters": [
+          {
+            "name": "rawTx",
+            "in": "path",
+            "description": "The raw transaction to extend",
+            "required": true,
+            "example": "0100000001b15ee60431ef57ec682790dec5a3c0d83a0c360633ea8308fbf6d5fc10a779670400000000ffffffff025c0d00000000000047512102f3e471222bb57a7d416c82bf81c627bfcd2bdc47f36e763ae69935bba4601ece21021580b888ff56feb27f17f08802ebed26258c23697d6a462d43fc13b565fda2dd52aeaa0a0000000000001976a914946cb2e08075bcbaf157e47bcb67eb2b2339d24288ac00000000",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "prevTxs",
+            "in": "path",
+            "description": "A JSON array of transaction inputs",
+            "required": true,
+            "example": "[{\"txid\":\"6779a710fcd5f6fb0883ea3306360c3ad8c0a3c5de902768ec57ef3104e65eb1\",\"vout\":4,\"scriptPubKey\":\"76a9147b25205fd98d462880a3e5b0541235831ae959e588ac\",\"value\":0.00068257}]",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "destination",
+            "in": "path",
+            "description": "The destination for the change",
+            "required": true,
+            "example": "bchtest:qq2j9gp97gm9a6lwvhxc4zu28qvqm0x4j5e72v7ejg",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fee",
+            "in": "path",
+            "description": "The desired transaction fees",
+            "required": true,
+            "example": 0.000035,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "position",
+            "in": "query",
+            "description": "The position of the change output (default: first position)",
+            "required": false,
+            "example": 1,
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful response"
+          },
+          "400": {
+            "description": "Received an invalid block height.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "status": 500,
+                  "message": "Received an invalid block height."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/rawtransactions/input/{rawTx}/{txid}/{n}": {
+      "post": {
+        "tags": ["rawtransactions"],
+        "summary": "createRawTxInput",
+        "description": "Adds a transaction input to the transaction.API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+        "operationId": "rawTransactionsInput",
+        "parameters": [
+          {
+            "name": "rawTx",
+            "in": "path",
+            "description": "The raw transaction to extend",
+            "required": true,
+            "example": "01000000000000000000",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "txid",
+            "in": "path",
+            "description": "The hash of the input transaction",
+            "required": true,
+            "example": "b006729017df05eda586df9ad3f8ccfee5be340aadf88155b784d1fc0e8342ee",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "n",
+            "in": "path",
+            "description": "The index of the transaction output used as input",
+            "required": true,
+            "example": 0,
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful response"
+          }
+        }
+      }
+    },
+    "/rawtransactions/opReturn/{rawTx}/{payload}": {
+      "post": {
+        "tags": ["rawtransactions"],
+        "summary": "createRawTxOpReturn",
+        "description": "Adds a payload with class C (op-return) encoding to the transaction.API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+        "operationId": "rawTransactionsOpReturn",
+        "parameters": [
+          {
+            "name": "rawTx",
+            "in": "path",
+            "description": "The raw transaction to extend",
+            "required": true,
+            "example": "01000000000000000000",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "payload",
+            "in": "path",
+            "description": "The hex-encoded payload to add",
+            "required": true,
+            "example": "00000000000000020000000006dac2c0",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful response"
+          }
+        }
+      }
+    },
+    "/rawtransactions/reference/{rawTx}/{destination}": {
+      "post": {
+        "tags": ["rawtransactions"],
+        "summary": "createRawTxReference",
+        "description": "Adds a reference output to the transaction. API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+        "operationId": "rawTransactionsReference",
+        "parameters": [
+          {
+            "name": "rawTx",
+            "in": "path",
+            "description": "The raw transaction to extend",
+            "required": true,
+            "example": "0100000001a7a9402ecd77f3c9f745793c9ec805bfa2e14b89877581c734c774864247e6f50400000000ffffffff03aa0a0000000000001976a9146d18edfe073d53f84dd491dae1379f8fb0dfe5d488ac5c0d0000000000004751210252ce4bdd3ce38b4ebbc5a6e1343608230da508ff12d23d85b58c964204c4cef3210294cc195fc096f87d0f813a337ae7e5f961b1c8a18f1f8604a909b3a5121f065b52aeaa0a0000000000001976a914946cb2e08075bcbaf157e47bcb67eb2b2339d24288ac00000000",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "destination",
+            "in": "path",
+            "description": "The reference address or destination",
+            "required": true,
+            "example": "bchtest:qq2j9gp97gm9a6lwvhxc4zu28qvqm0x4j5e72v7ejg",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "amount",
+            "in": "query",
+            "description": "The optional reference amount (minimal by default)",
+            "required": false,
+            "example": 0.005,
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful response"
+          }
+        }
+      }
+    },
     "/transaction/details/{txid}": {
       "get": {
         "tags": ["transaction"],

--- a/swaggerJSONFilesBuilt/mainnet/paths.json
+++ b/swaggerJSONFilesBuilt/mainnet/paths.json
@@ -1244,6 +1244,303 @@
 				}
 			}
 		},
+		"/rawtransactions/sendRawTransaction/{hex}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "Submits raw transaction to local node and network.",
+				"description": "Submits raw transaction (serialized, hex-encoded) to local node and network. Also see createrawtransaction and signrawtransaction calls.",
+				"operationId": "sendRawTransaction",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "hex",
+						"description": "The hex string of the raw transaction",
+						"required": true,
+						"example": "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac00000000",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful operation"
+					},
+					"400": {
+						"description": "Transaction not found"
+					}
+				}
+			}
+		},
+		"/rawtransactions/create/{inputs}/{outputs}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "createRawTxChange",
+				"description": "Create a transaction spending the given inputs and creating new outputs. API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+				"operationId": "rawTransactionsCreate",
+				"parameters": [
+					{
+						"name": "inputs",
+						"in": "path",
+						"description": "A json array of json objects",
+						"required": true,
+						"example": "[{\"txid\":\"myid\",\"vout\":0}]",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "outputs",
+						"in": "path",
+						"description": "A json object with outputs",
+						"required": true,
+						"example": "{}",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "locktime",
+						"in": "query",
+						"description": "Raw locktime. Non-0 value also locktime-activates inputs",
+						"required": false,
+						"example": 0,
+						"schema": {
+							"type": "number"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful response"
+					},
+					"400": {
+						"description": "Received an invalid block height.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"status": 500,
+									"message": "Received an invalid block height."
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/rawtransactions/change/{rawTx}/{prevTxs}/{destination}/{fee}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "createRawTxChange",
+				"description": "Adds a change output to the transaction.API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+				"operationId": "rawTransactionsChange",
+				"parameters": [
+					{
+						"name": "rawTx",
+						"in": "path",
+						"description": "The raw transaction to extend",
+						"required": true,
+						"example": "0100000001b15ee60431ef57ec682790dec5a3c0d83a0c360633ea8308fbf6d5fc10a779670400000000ffffffff025c0d00000000000047512102f3e471222bb57a7d416c82bf81c627bfcd2bdc47f36e763ae69935bba4601ece21021580b888ff56feb27f17f08802ebed26258c23697d6a462d43fc13b565fda2dd52aeaa0a0000000000001976a914946cb2e08075bcbaf157e47bcb67eb2b2339d24288ac00000000",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "prevTxs",
+						"in": "path",
+						"description": "A JSON array of transaction inputs",
+						"required": true,
+						"example": "[{\"txid\":\"6779a710fcd5f6fb0883ea3306360c3ad8c0a3c5de902768ec57ef3104e65eb1\",\"vout\":4,\"scriptPubKey\":\"76a9147b25205fd98d462880a3e5b0541235831ae959e588ac\",\"value\":0.00068257}]",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "destination",
+						"in": "path",
+						"description": "The destination for the change",
+						"required": true,
+						"example": "bchtest:qq2j9gp97gm9a6lwvhxc4zu28qvqm0x4j5e72v7ejg",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "fee",
+						"in": "path",
+						"description": "The desired transaction fees",
+						"required": true,
+						"example": 0.000035,
+						"schema": {
+							"type": "number"
+						}
+					},
+					{
+						"name": "position",
+						"in": "query",
+						"description": "The position of the change output (default: first position)",
+						"required": false,
+						"example": 1,
+						"schema": {
+							"type": "number"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful response"
+					},
+					"400": {
+						"description": "Received an invalid block height.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"status": 500,
+									"message": "Received an invalid block height."
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/rawtransactions/input/{rawTx}/{txid}/{n}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "createRawTxInput",
+				"description": "Adds a transaction input to the transaction.API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+				"operationId": "rawTransactionsInput",
+				"parameters": [
+					{
+						"name": "rawTx",
+						"in": "path",
+						"description": "The raw transaction to extend",
+						"required": true,
+						"example": "01000000000000000000",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "txid",
+						"in": "path",
+						"description": "The hash of the input transaction",
+						"required": true,
+						"example": "b006729017df05eda586df9ad3f8ccfee5be340aadf88155b784d1fc0e8342ee",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "n",
+						"in": "path",
+						"description": "The index of the transaction output used as input",
+						"required": true,
+						"example": 0,
+						"schema": {
+							"type": "number"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful response"
+					}
+				}
+			}
+		},
+		"/rawtransactions/opReturn/{rawTx}/{payload}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "createRawTxOpReturn",
+				"description": "Adds a payload with class C (op-return) encoding to the transaction.API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+				"operationId": "rawTransactionsOpReturn",
+				"parameters": [
+					{
+						"name": "rawTx",
+						"in": "path",
+						"description": "The raw transaction to extend",
+						"required": true,
+						"example": "01000000000000000000",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "payload",
+						"in": "path",
+						"description": "The hex-encoded payload to add",
+						"required": true,
+						"example": "00000000000000020000000006dac2c0",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful response"
+					}
+				}
+			}
+		},
+		"/rawtransactions/reference/{rawTx}/{destination}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "createRawTxReference",
+				"description": "Adds a reference output to the transaction. API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+				"operationId": "rawTransactionsReference",
+				"parameters": [
+					{
+						"name": "rawTx",
+						"in": "path",
+						"description": "The raw transaction to extend",
+						"required": true,
+						"example": "0100000001a7a9402ecd77f3c9f745793c9ec805bfa2e14b89877581c734c774864247e6f50400000000ffffffff03aa0a0000000000001976a9146d18edfe073d53f84dd491dae1379f8fb0dfe5d488ac5c0d0000000000004751210252ce4bdd3ce38b4ebbc5a6e1343608230da508ff12d23d85b58c964204c4cef3210294cc195fc096f87d0f813a337ae7e5f961b1c8a18f1f8604a909b3a5121f065b52aeaa0a0000000000001976a914946cb2e08075bcbaf157e47bcb67eb2b2339d24288ac00000000",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "destination",
+						"in": "path",
+						"description": "The reference address or destination",
+						"required": true,
+						"example": "bchtest:qq2j9gp97gm9a6lwvhxc4zu28qvqm0x4j5e72v7ejg",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "amount",
+						"in": "query",
+						"description": "The optional reference amount (minimal by default)",
+						"required": false,
+						"example": 0.005,
+						"schema": {
+							"type": "number"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful response"
+					}
+				}
+			}
+		},
 		"/transaction/details/{txid}": {
 			"get": {
 				"tags": [

--- a/swaggerJSONFilesBuilt/testnet/paths.json
+++ b/swaggerJSONFilesBuilt/testnet/paths.json
@@ -1244,6 +1244,303 @@
 				}
 			}
 		},
+		"/rawtransactions/sendRawTransaction/{hex}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "Submits raw transaction to local node and network.",
+				"description": "Submits raw transaction (serialized, hex-encoded) to local node and network. Also see createrawtransaction and signrawtransaction calls.",
+				"operationId": "sendRawTransaction",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "hex",
+						"description": "The hex string of the raw transaction",
+						"required": true,
+						"example": "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac00000000",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful operation"
+					},
+					"400": {
+						"description": "Transaction not found"
+					}
+				}
+			}
+		},
+		"/rawtransactions/create/{inputs}/{outputs}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "createRawTxChange",
+				"description": "Create a transaction spending the given inputs and creating new outputs. API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+				"operationId": "rawTransactionsCreate",
+				"parameters": [
+					{
+						"name": "inputs",
+						"in": "path",
+						"description": "A json array of json objects",
+						"required": true,
+						"example": "[{\"txid\":\"myid\",\"vout\":0}]",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "outputs",
+						"in": "path",
+						"description": "A json object with outputs",
+						"required": true,
+						"example": "{}",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "locktime",
+						"in": "query",
+						"description": "Raw locktime. Non-0 value also locktime-activates inputs",
+						"required": false,
+						"example": 0,
+						"schema": {
+							"type": "number"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful response"
+					},
+					"400": {
+						"description": "Received an invalid block height.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"status": 500,
+									"message": "Received an invalid block height."
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/rawtransactions/change/{rawTx}/{prevTxs}/{destination}/{fee}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "createRawTxChange",
+				"description": "Adds a change output to the transaction.API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+				"operationId": "rawTransactionsChange",
+				"parameters": [
+					{
+						"name": "rawTx",
+						"in": "path",
+						"description": "The raw transaction to extend",
+						"required": true,
+						"example": "0100000001b15ee60431ef57ec682790dec5a3c0d83a0c360633ea8308fbf6d5fc10a779670400000000ffffffff025c0d00000000000047512102f3e471222bb57a7d416c82bf81c627bfcd2bdc47f36e763ae69935bba4601ece21021580b888ff56feb27f17f08802ebed26258c23697d6a462d43fc13b565fda2dd52aeaa0a0000000000001976a914946cb2e08075bcbaf157e47bcb67eb2b2339d24288ac00000000",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "prevTxs",
+						"in": "path",
+						"description": "A JSON array of transaction inputs",
+						"required": true,
+						"example": "[{\"txid\":\"6779a710fcd5f6fb0883ea3306360c3ad8c0a3c5de902768ec57ef3104e65eb1\",\"vout\":4,\"scriptPubKey\":\"76a9147b25205fd98d462880a3e5b0541235831ae959e588ac\",\"value\":0.00068257}]",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "destination",
+						"in": "path",
+						"description": "The destination for the change",
+						"required": true,
+						"example": "bchtest:qq2j9gp97gm9a6lwvhxc4zu28qvqm0x4j5e72v7ejg",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "fee",
+						"in": "path",
+						"description": "The desired transaction fees",
+						"required": true,
+						"example": 0.000035,
+						"schema": {
+							"type": "number"
+						}
+					},
+					{
+						"name": "position",
+						"in": "query",
+						"description": "The position of the change output (default: first position)",
+						"required": false,
+						"example": 1,
+						"schema": {
+							"type": "number"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful response"
+					},
+					"400": {
+						"description": "Received an invalid block height.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"status": 500,
+									"message": "Received an invalid block height."
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/rawtransactions/input/{rawTx}/{txid}/{n}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "createRawTxInput",
+				"description": "Adds a transaction input to the transaction.API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+				"operationId": "rawTransactionsInput",
+				"parameters": [
+					{
+						"name": "rawTx",
+						"in": "path",
+						"description": "The raw transaction to extend",
+						"required": true,
+						"example": "01000000000000000000",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "txid",
+						"in": "path",
+						"description": "The hash of the input transaction",
+						"required": true,
+						"example": "b006729017df05eda586df9ad3f8ccfee5be340aadf88155b784d1fc0e8342ee",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "n",
+						"in": "path",
+						"description": "The index of the transaction output used as input",
+						"required": true,
+						"example": 0,
+						"schema": {
+							"type": "number"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful response"
+					}
+				}
+			}
+		},
+		"/rawtransactions/opReturn/{rawTx}/{payload}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "createRawTxOpReturn",
+				"description": "Adds a payload with class C (op-return) encoding to the transaction.API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+				"operationId": "rawTransactionsOpReturn",
+				"parameters": [
+					{
+						"name": "rawTx",
+						"in": "path",
+						"description": "The raw transaction to extend",
+						"required": true,
+						"example": "01000000000000000000",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "payload",
+						"in": "path",
+						"description": "The hex-encoded payload to add",
+						"required": true,
+						"example": "00000000000000020000000006dac2c0",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful response"
+					}
+				}
+			}
+		},
+		"/rawtransactions/reference/{rawTx}/{destination}": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "createRawTxReference",
+				"description": "Adds a reference output to the transaction. API Reference: https://developer.bitcoin.com/wormhole/docs/rawTransactions",
+				"operationId": "rawTransactionsReference",
+				"parameters": [
+					{
+						"name": "rawTx",
+						"in": "path",
+						"description": "The raw transaction to extend",
+						"required": true,
+						"example": "0100000001a7a9402ecd77f3c9f745793c9ec805bfa2e14b89877581c734c774864247e6f50400000000ffffffff03aa0a0000000000001976a9146d18edfe073d53f84dd491dae1379f8fb0dfe5d488ac5c0d0000000000004751210252ce4bdd3ce38b4ebbc5a6e1343608230da508ff12d23d85b58c964204c4cef3210294cc195fc096f87d0f813a337ae7e5f961b1c8a18f1f8604a909b3a5121f065b52aeaa0a0000000000001976a914946cb2e08075bcbaf157e47bcb67eb2b2339d24288ac00000000",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "destination",
+						"in": "path",
+						"description": "The reference address or destination",
+						"required": true,
+						"example": "bchtest:qq2j9gp97gm9a6lwvhxc4zu28qvqm0x4j5e72v7ejg",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "amount",
+						"in": "query",
+						"description": "The optional reference amount (minimal by default)",
+						"required": false,
+						"example": 0.005,
+						"schema": {
+							"type": "number"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful response"
+					}
+				}
+			}
+		},
 		"/transaction/details/{txid}": {
 			"get": {
 				"tags": [


### PR DESCRIPTION
* /rawtransactions/sendRawTransaction/{hex}
* /rawtransactions/create/{inputs}/{outputs}
* /rawtransactions/change/{rawTx}/{prevTxs}/{destination}/{fee}
* /rawtransactions/input/{rawTx}/{txid}/{n}
* /rawtransactions/opReturn/{rawTx}/{payload}
* /rawtransactions/reference/{rawTx}/{destination}