### PR TITLE
Fixes problem with bulk Address.unconfirmed endpoint

### DIFF
--- a/src/routes/v2/address.ts
+++ b/src/routes/v2/address.ts
@@ -494,26 +494,51 @@ async function unconfirmedBulk(
       }
     }
 
+    // Collect an array of promises.
+    const promises = addresses.map((address) => utxoFromInsight(address))
+
+    // Wait for all parallel Insight requests to return.
+    let result: Array<any> = await axios.all(promises)
+
+    // Loop through each result
+    const finalResult = result.map(elem => {
+      //console.log(`elem: ${util.inspect(elem)}`)
+
+      // Filter out confirmed transactions.
+      const unconfirmedUtxos = elem.utxos.filter((utxo: any) => {
+        utxo.confirmations === 0
+      })
+
+      elem.utxos = unconfirmedUtxos
+
+      return elem
+    })
+    //console.log(`finalResult: ${util.inspect(finalResult)}`)
+
+/*
     // Loop through each address and collect an array of promises.
     addresses = addresses.map(async (address: any, index: number) => {
 
       const retData = await utxoFromInsight(address)
+      const unconfirmedUTXOs = []
 
       // Loop through each returned UTXO.
       for (let j = 0; j < retData.utxos.length; j++) {
         const thisUtxo = (<any>retData.utxos)[j]
 
-        // Only interested in UTXOs with no confirmations.
-        if (thisUtxo.confirmations !== 0) return thisUtxo
-      }
-    })
 
-    // Wait for all parallel Insight requests to return.
-    let result: Array<any> = await axios.all(addresses)
+        // Only interested in UTXOs with no confirmations.
+        //if (thisUtxo.confirmations !== 0) return thisUtxo
+        if (thisUtxo.confirmations === 0) unconfirmedUTXOs.push(thisUtxo)
+      }
+      return unconfirmedUTXOs
+    })
+*/
+
 
     // Return the array of retrieved address information.
     res.status(200)
-    return res.json(result)
+    return res.json(finalResult)
 
   } catch (err) {
     // Attempt to decode the error message.

--- a/src/routes/v2/address.ts
+++ b/src/routes/v2/address.ts
@@ -513,28 +513,6 @@ async function unconfirmedBulk(
 
       return elem
     })
-    //console.log(`finalResult: ${util.inspect(finalResult)}`)
-
-/*
-    // Loop through each address and collect an array of promises.
-    addresses = addresses.map(async (address: any, index: number) => {
-
-      const retData = await utxoFromInsight(address)
-      const unconfirmedUTXOs = []
-
-      // Loop through each returned UTXO.
-      for (let j = 0; j < retData.utxos.length; j++) {
-        const thisUtxo = (<any>retData.utxos)[j]
-
-
-        // Only interested in UTXOs with no confirmations.
-        //if (thisUtxo.confirmations !== 0) return thisUtxo
-        if (thisUtxo.confirmations === 0) unconfirmedUTXOs.push(thisUtxo)
-      }
-      return unconfirmedUTXOs
-    })
-*/
-
 
     // Return the array of retrieved address information.
     res.status(200)

--- a/test/v2/address.js
+++ b/test/v2/address.js
@@ -830,6 +830,7 @@ describe("#AddressRouter", () => {
       // Call the details API.
       const result = await unconfirmedBulk(req, res)
       //console.log(`result: ${util.inspect(result)}`)
+      //console.log(`result[0].utxos: ${util.inspect(result[0].utxos)}`)
 
       assert.isArray(result, "result should be an array")
 


### PR DESCRIPTION
The output of the bulk unconfirmed endpoint was returning data that was incorrect and very different from the single unconfirmed endpoint. This PR fixes that problem. Verifies that single and bulk are now output the same data.