### PR TITLE
Replacing misspelled property coming from Insight

### DIFF
--- a/dist/public/bitcoin-com-mainnet-rest-v2.json
+++ b/dist/public/bitcoin-com-mainnet-rest-v2.json
@@ -1319,7 +1319,7 @@
 	"openapi": "3.0.0",
 	"info": {
 		"description": "rest.bitcoin.com is the REST layer for Bitcoin.com's Cloud. More info: [developer.bitcoin.com/rest](https://developer.bitcoin.com/rest). Chatroom [geni.us/CashDev](http://geni.us/CashDev)",
-		"version": "2.0.5",
+		"version": "2.0.6",
 		"title": "REST",
 		"license": {
 			"name": "MIT",

--- a/dist/public/bitcoin-com-testnet-rest-v2.json
+++ b/dist/public/bitcoin-com-testnet-rest-v2.json
@@ -1319,7 +1319,7 @@
 	"openapi": "3.0.0",
 	"info": {
 		"description": "trest.bitcoin.com is the REST layer for Bitcoin.com's Cloud. More info: [developer.bitcoin.com/rest](https://developer.bitcoin.com/rest). Chatroom [geni.us/CashDev](http://geni.us/CashDev)",
-		"version": "2.0.5",
+		"version": "2.0.6",
 		"title": "REST",
 		"license": {
 			"name": "MIT",

--- a/src/routes/v2/address.ts
+++ b/src/routes/v2/address.ts
@@ -112,9 +112,10 @@ async function detailsFromInsight(
     // Query the Insight server.
     const axiosResponse = await axios.get(path)
     const retData = axiosResponse.data
+    //console.log(`retData: ${util.inspect(retData)}`)
 
     // Calculate pagesTotal from response
-    const pagesTotal = Math.ceil(retData.txAppearances / PAGE_SIZE)
+    const pagesTotal = Math.ceil(retData.txApperances / PAGE_SIZE)
 
     // Append different address formats to the return data.
     retData.legacyAddress = BITBOX.Address.toLegacyAddress(retData.addrStr)

--- a/swaggerJSONFilesBuilt/mainnet/info.json
+++ b/swaggerJSONFilesBuilt/mainnet/info.json
@@ -2,7 +2,7 @@
 	"openapi": "3.0.0",
 	"info": {
 		"description": "rest.bitcoin.com is the REST layer for Bitcoin.com's Cloud. More info: [developer.bitcoin.com/rest](https://developer.bitcoin.com/rest). Chatroom [geni.us/CashDev](http://geni.us/CashDev)",
-		"version": "2.0.5",
+		"version": "2.0.6",
 		"title": "REST",
 		"license": {
 			"name": "MIT",

--- a/swaggerJSONFilesBuilt/testnet/info.json
+++ b/swaggerJSONFilesBuilt/testnet/info.json
@@ -2,7 +2,7 @@
 	"openapi": "3.0.0",
 	"info": {
 		"description": "trest.bitcoin.com is the REST layer for Bitcoin.com's Cloud. More info: [developer.bitcoin.com/rest](https://developer.bitcoin.com/rest). Chatroom [geni.us/CashDev](http://geni.us/CashDev)",
-		"version": "2.0.5",
+		"version": "2.0.6",
 		"title": "REST",
 		"license": {
 			"name": "MIT",

--- a/test/v2/address.js
+++ b/test/v2/address.js
@@ -88,6 +88,7 @@ describe("#AddressRouter", () => {
       req.body = {}
 
       const result = await detailsBulk(req, res)
+      //console.log(`result: ${util.inspect(result)}`)
 
       assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
       assert.include(
@@ -237,7 +238,7 @@ describe("#AddressRouter", () => {
 
       // Call the details API.
       const result = await detailsBulk(req, res)
-      // console.log(`result: ${util.inspect(result)}`)
+      //console.log(`result: ${util.inspect(result)}`)
 
       assert.equal(result[0].pagesTotal, 1)
     })
@@ -269,8 +270,8 @@ describe("#AddressRouter", () => {
         "totalSentSat",
         "unconfirmedBalance",
         "unconfirmedBalanceSat",
-        "unconfirmedTxAppearances",
-        "txAppearances",
+        "unconfirmedTxApperances",
+        "txApperances",
         "transactions",
         "legacyAddress",
         "cashAddress",
@@ -452,8 +453,8 @@ describe("#AddressRouter", () => {
         "totalSentSat",
         "unconfirmedBalance",
         "unconfirmedBalanceSat",
-        "unconfirmedTxAppearances",
-        "txAppearances",
+        "unconfirmedTxApperances",
+        "txApperances",
         "transactions",
         "legacyAddress",
         "cashAddress",

--- a/test/v2/mocks/address-mock.js
+++ b/test/v2/mocks/address-mock.js
@@ -14,8 +14,8 @@ const mockAddressDetails = {
   totalSentSat: 2049449,
   unconfirmedBalance: 0,
   unconfirmedBalanceSat: 0,
-  unconfirmedTxAppearances: 0,
-  txAppearances: 3,
+  unconfirmedTxApperances: 0,
+  txApperances: 3,
   transactions: [
     "2dc053f55a666a3d2a08b1c680b704d62a55506d14ad884add87edcc56b9277d",
     "544c15ce35c0f2e808d28f29d6587f1ec9276233e29856b7f2938cf0daef0026",


### PR DESCRIPTION
the `/addr` Insight API call returns two incorrectly spelled properties: `txApperances` and `unconfirmedTxApperances`

We don't have any control over the data coming from Insight API, so we have no control over the proper spelling of these properties. A previous commit corrected the spelling and broke the integration tests. Unit tests still passed, because the mocks were updated with the correct spelling, which is why the CI didn't catch it.

This PR corrects the code by replacing the misspelled properties. Integration tests are now passing again.