### PR TITLE
Fix getRawTransactions Bulk in Swagger UI

### DIFF
--- a/dist/public/bitcoin-com-mainnet-rest-v2.json
+++ b/dist/public/bitcoin-com-mainnet-rest-v2.json
@@ -2571,6 +2571,35 @@
 				}
 			}
 		},
+		"/rawtransactions/getRawTransaction": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "Return raw transaction data for multiple transactions.",
+				"description": "Return the raw transaction data for multiple transactions. If verbose is 'true', returns an Object with information about 'txid'. If verbose is 'false' or omitted, returns a string that is serialized, hex-encoded data for 'txid'.",
+				"operationId": "getRawTransaction",
+				"requestBody": {
+					"description": "Array of txids",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Txids"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "successful operation"
+					},
+					"400": {
+						"description": "Transaction not found"
+					}
+				}
+			}
+		},
 		"/rawtransactions/sendRawTransaction": {
 			"post": {
 				"tags": [

--- a/dist/public/bitcoin-com-testnet-rest-v2.json
+++ b/dist/public/bitcoin-com-testnet-rest-v2.json
@@ -2571,6 +2571,35 @@
 				}
 			}
 		},
+		"/rawtransactions/getRawTransaction": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "Return raw transaction data for multiple transactions.",
+				"description": "Return the raw transaction data for multiple transactions. If verbose is 'true', returns an Object with information about 'txid'. If verbose is 'false' or omitted, returns a string that is serialized, hex-encoded data for 'txid'.",
+				"operationId": "getRawTransaction",
+				"requestBody": {
+					"description": "Array of txids",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Txids"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "successful operation"
+					},
+					"400": {
+						"description": "Transaction not found"
+					}
+				}
+			}
+		},
 		"/rawtransactions/sendRawTransaction": {
 			"post": {
 				"tags": [

--- a/swaggerJSONFiles/paths.json
+++ b/swaggerJSONFiles/paths.json
@@ -1174,6 +1174,33 @@
         }
       }
     },
+    "/rawtransactions/getRawTransaction": {
+      "post": {
+        "tags": ["rawtransactions"],
+        "summary": "Return raw transaction data for multiple transactions.",
+        "description": "Return the raw transaction data for multiple transactions. If verbose is 'true', returns an Object with information about 'txid'. If verbose is 'false' or omitted, returns a string that is serialized, hex-encoded data for 'txid'.",
+        "operationId": "getRawTransaction",
+        "requestBody": {
+          "description": "Array of txids",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Txids"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          },
+          "400": {
+            "description": "Transaction not found"
+          }
+        }
+      }
+    },
     "/rawtransactions/sendRawTransaction": {
       "post": {
         "tags": ["rawtransactions"],

--- a/swaggerJSONFilesBuilt/mainnet/paths.json
+++ b/swaggerJSONFilesBuilt/mainnet/paths.json
@@ -1244,6 +1244,35 @@
 				}
 			}
 		},
+		"/rawtransactions/getRawTransaction": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "Return raw transaction data for multiple transactions.",
+				"description": "Return the raw transaction data for multiple transactions. If verbose is 'true', returns an Object with information about 'txid'. If verbose is 'false' or omitted, returns a string that is serialized, hex-encoded data for 'txid'.",
+				"operationId": "getRawTransaction",
+				"requestBody": {
+					"description": "Array of txids",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Txids"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "successful operation"
+					},
+					"400": {
+						"description": "Transaction not found"
+					}
+				}
+			}
+		},
 		"/rawtransactions/sendRawTransaction": {
 			"post": {
 				"tags": [

--- a/swaggerJSONFilesBuilt/testnet/paths.json
+++ b/swaggerJSONFilesBuilt/testnet/paths.json
@@ -1244,6 +1244,35 @@
 				}
 			}
 		},
+		"/rawtransactions/getRawTransaction": {
+			"post": {
+				"tags": [
+					"rawtransactions"
+				],
+				"summary": "Return raw transaction data for multiple transactions.",
+				"description": "Return the raw transaction data for multiple transactions. If verbose is 'true', returns an Object with information about 'txid'. If verbose is 'false' or omitted, returns a string that is serialized, hex-encoded data for 'txid'.",
+				"operationId": "getRawTransaction",
+				"requestBody": {
+					"description": "Array of txids",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Txids"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "successful operation"
+					},
+					"400": {
+						"description": "Transaction not found"
+					}
+				}
+			}
+		},
 		"/rawtransactions/sendRawTransaction": {
 			"post": {
 				"tags": [


### PR DESCRIPTION
The scope of this PR is to add a bulk endpoint for getRawTransactions in the Swagger UI. Addresses Issue #233 

---

This PR has part of the UI  implemented, but it's acting funny: 
- Clicking on the POST (bulk) call will open both the POST and GET calls.
- I'm also not sure how to add the verbose flag to the POST call.
