### PR TITLE
tsconfig.json update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3729,22 +3729,22 @@
         "babel-preset-es2015": "^6.24.1",
         "babel-register": "^6.26.0",
         "bc-bip68": "^1.0.5",
-        "bch-wallet-bridge.js": "github:web3bch/bch-wallet-bridge.js#master",
+        "bch-wallet-bridge.js": "github:web3bch/bch-wallet-bridge.js#f73558eaf3a98ba2a23de3c9cbbd582b30ff19eb",
         "bigi": "^1.4.2",
-        "bip21": "github:Bitcoin-com/bip21",
-        "bip32-utils": "github:Bitcoin-com/bip32-utils#0.13.1",
+        "bip21": "github:Bitcoin-com/bip21#28f8d03a3a16ed11eb5b963248ed1be8c46c6d6f",
+        "bip32-utils": "github:Bitcoin-com/bip32-utils#b8a33ebd0a0ac39de7cd987e5c3f77a8c5d84e58",
         "bip38": "^2.0.2",
         "bip39": "^2.5.0",
         "bip66": "^1.1.5",
-        "bitcoincash-ops": "github:Bitcoin-com/bitcoincash-ops#2.0.0",
-        "bitcoincashjs-lib": "github:Bitcoin-com/bitcoincashjs-lib#3.4.4",
+        "bitcoincash-ops": "github:Bitcoin-com/bitcoincash-ops#6ab82cc7326c67236f3b2d9d0457258ac2ef48e3",
+        "bitcoincashjs-lib": "github:Bitcoin-com/bitcoincashjs-lib#61ffec3878fd959d2a8a62f570a122ff801d78b6",
         "bitcoinjs-message": "^2.0.0",
         "bs58": "^4.0.1",
         "buffer": "^5.1.0",
         "cashaddrjs": "^0.2.9",
         "chalk": "^2.3.0",
         "clear": "0.0.1",
-        "coininfo": "github:Bitcoin-com/coininfo",
+        "coininfo": "github:Bitcoin-com/coininfo#eece2c6141d08c3e7783929f2a1e1e681aa1a82c",
         "commander": "^2.13.0",
         "cp-file": "^5.0.0",
         "ecurve": "^1.0.6",
@@ -3845,13 +3845,13 @@
         "bech32": "^1.1.2",
         "bigi": "^1.4.0",
         "bip66": "^1.1.0",
-        "bitcoincash-ops": "github:Bitcoin-com/bitcoincash-ops#2.0.0",
+        "bitcoincash-ops": "github:Bitcoin-com/bitcoincash-ops#6ab82cc7326c67236f3b2d9d0457258ac2ef48e3",
         "bs58check": "^2.0.0",
         "create-hash": "^1.1.0",
         "create-hmac": "^1.1.3",
         "ecurve": "^1.0.0",
         "merkle-lib": "^2.0.10",
-        "pushdata-bitcoin": "github:Bitcoin-com/pushdata-bitcoin#1.2.1",
+        "pushdata-bitcoin": "github:Bitcoin-com/pushdata-bitcoin#9b75eebe597853c6eeaec3e6c44b6d9c9cd7ee86",
         "randombytes": "^2.0.1",
         "safe-buffer": "^5.0.1",
         "typeforce": "^1.11.3",
@@ -3879,6 +3879,16 @@
         "typeforce": "^1.11.3",
         "varuint-bitcoin": "^1.0.4",
         "wif": "^2.0.1"
+      },
+      "dependencies": {
+        "pushdata-bitcoin": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
+          "integrity": "sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=",
+          "requires": {
+            "bitcoin-ops": "^1.3.0"
+          }
+        }
       }
     },
     "bitcoinjs-message": {
@@ -4615,14 +4625,12 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "optional": true
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -8369,8 +8377,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8388,13 +8395,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8407,18 +8412,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8521,8 +8523,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8532,7 +8533,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8545,20 +8545,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8575,7 +8572,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8648,8 +8644,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8659,7 +8654,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8735,8 +8729,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8766,7 +8759,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8784,7 +8776,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8823,13 +8814,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -15976,7 +15965,6 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -17159,8 +17147,7 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",
@@ -19047,23 +19034,23 @@
             "babel-preset-es2015": "^6.24.1",
             "babel-register": "^6.26.0",
             "bc-bip68": "^1.0.5",
-            "bch-wallet-bridge.js": "github:web3bch/bch-wallet-bridge.js#master",
+            "bch-wallet-bridge.js": "github:web3bch/bch-wallet-bridge.js#f73558eaf3a98ba2a23de3c9cbbd582b30ff19eb",
             "bigi": "^1.4.2",
-            "bip21": "github:Bitcoin-com/bip21",
-            "bip32-utils": "github:Bitcoin-com/bip32-utils#0.13.0",
+            "bip21": "github:Bitcoin-com/bip21#28f8d03a3a16ed11eb5b963248ed1be8c46c6d6f",
+            "bip32-utils": "github:Bitcoin-com/bip32-utils#966fb8f0e0d4c667e4ee89adfa20c2078d66887c",
             "bip38": "^2.0.2",
             "bip39": "^2.5.0",
             "bip66": "^1.1.5",
-            "bitcoin-ops": "github:Bitcoin-com/bitcoincash-ops#1.5.0",
+            "bitcoin-ops": "github:Bitcoin-com/bitcoincash-ops#f1363d462fd044f35f94a220bf9568e25d985646",
             "bitcoin-txdecoder": "0.0.3",
-            "bitcoincashjs-lib": "github:Bitcoin-com/bitcoincashjs-lib#3.3.4",
+            "bitcoincashjs-lib": "github:Bitcoin-com/bitcoincashjs-lib#12fa5fe9b535816b54b9efedd6caf278d3e55b90",
             "bitcoinjs-message": "^2.0.0",
             "bs58": "^4.0.1",
             "buffer": "^5.1.0",
             "cashaddrjs": "^0.2.9",
             "chalk": "^2.3.0",
             "clear": "0.0.1",
-            "coininfo": "github:Bitcoin-com/coininfo",
+            "coininfo": "github:Bitcoin-com/coininfo#eece2c6141d08c3e7783929f2a1e1e681aa1a82c",
             "commander": "^2.13.0",
             "cp-file": "^5.0.0",
             "ecurve": "^1.0.6",
@@ -19109,6 +19096,14 @@
             "typeforce": "^1.11.3",
             "varuint-bitcoin": "^1.0.4",
             "wif": "^2.0.1"
+          },
+          "dependencies": {
+            "bitcoin-ops": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
+              "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow==",
+              "dev": true
+            }
           }
         },
         "chalk": {
@@ -19127,6 +19122,23 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
           "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
           "dev": true
+        },
+        "pushdata-bitcoin": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
+          "integrity": "sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=",
+          "dev": true,
+          "requires": {
+            "bitcoin-ops": "^1.3.0"
+          },
+          "dependencies": {
+            "bitcoin-ops": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
+              "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow==",
+              "dev": true
+            }
+          }
         },
         "supports-color": {
           "version": "5.5.0",
@@ -19920,7 +19932,7 @@
       "version": "github:Bitcoin-com/pushdata-bitcoin#9b75eebe597853c6eeaec3e6c44b6d9c9cd7ee86",
       "from": "github:Bitcoin-com/pushdata-bitcoin#1.2.1",
       "requires": {
-        "bitcoincash-ops": "github:Bitcoin-com/bitcoincash-ops#2.0.0"
+        "bitcoincash-ops": "github:Bitcoin-com/bitcoincash-ops#6ab82cc7326c67236f3b2d9d0457258ac2ef48e3"
       }
     },
     "q": {
@@ -21297,12 +21309,12 @@
       "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
     },
     "slpjs": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/slpjs/-/slpjs-0.12.0.tgz",
-      "integrity": "sha512-d5Ar0SkmcQaC6uBcvpCsiLEf4by82GwnnaKVNWSWGnyOtayBu2cveSvXupnAfcTcJ//av1pAUSb6aTEtpQFlnA==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/slpjs/-/slpjs-0.12.2.tgz",
+      "integrity": "sha512-mmfYth58+oEYvMTk7SdE2cx+6bC22SKyJjkQUfibfvgIQFFaj70F33wn7nGM5qFrqAOM2meMKhd2ommDnxIoaw==",
       "requires": {
         "axios": "^0.18.0",
-        "bchaddrjs-slp": "git://github.com/simpleledger/bchaddrjs.git#master",
+        "bchaddrjs-slp": "git://github.com/simpleledger/bchaddrjs.git#ea05d679783a6737f2f99adc37ebf485dc64f006",
         "bignumber.js": "^7.2.1",
         "bitcore-lib-cash": "^0.19.0"
       },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "pg": "^6.2.3",
     "pg-hstore": "^2.3.2",
     "sequelize": "^3.30.4",
-    "slpjs": "0.12.0",
+    "slpjs": "0.12.2",
     "socket.io": "^2.1.1",
     "strftime": "^0.10.0",
     "swagger-stats": "^0.95.6",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,14 @@
 {
   "compilerOptions": {
     "outDir": "./dist/",
-    "noImplicitAny": true,
+    //"noImplicitAny": true,
     "baseUrl": ".",
     "module": "commonjs",
     "target": "es5",
     "allowJs": true,
-    "lib": ["es2015", "es2015.symbol", "dom"],
-    "typeRoots": ["node_modules/@types/"]
+    "lib": ["es2015", "es2015.symbol", "dom", "es2017"],
+    "typeRoots": ["node_modules/@types/"],
+    "downlevelIteration": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "test/**/*"]


### PR DESCRIPTION
TS was having issues because slpjs is transpiled to es6, not es5.  So when your comiles it fails due to:

1)  `"allowImplicityAny": false`, -- Relatively harmless to change to true

2) `"libs"` needs "es2017" due to slpjs use of new language features

3) `"downlevelIteration"` needs set to true due to use of `for..of` operator.  I'm not sure if a web version of this would need some shim or not. [see here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html#downlevelIteration)