### PR TITLE
rate limit by middleware for future auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Now you need to start REST and pass in the following environment variables
 - ZEROMQ_URL - The IP address of your full BCH node
 - NETWORK - mainnet or testnet depending on which network you're using
 - BITDB_URL - mainnet or testnet BITDB URL
+- RATE_LIMIT_MAX_REQUESTS (optional) - Rate limit per route per minute. Defaults to 60. Set to 0 to disable rate limit.
 
 Here's how the final command would look
 

--- a/dist/app.js
+++ b/dist/app.js
@@ -1,6 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var express = require("express");
+// Middleware
+var route_ratelimit_1 = require("./middleware/route-ratelimit");
 var path = require("path");
 var logger = require("morgan");
 var cookieParser = require("cookie-parser");
@@ -89,6 +91,8 @@ app.use("/" + v1prefix + "/" + "util", utilV1);
 app.use("/" + v1prefix + "/" + "dataRetrieval", dataRetrievalV1);
 app.use("/" + v1prefix + "/" + "payloadCreation", payloadCreationV1);
 app.use("/" + v1prefix + "/" + "slp", slpV1);
+// Rate limit on all v2 routes
+app.use("/" + v2prefix + "/", route_ratelimit_1.routeRateLimit);
 app.use("/", indexV2);
 app.use("/" + v2prefix + "/" + "health-check", healthCheckV2);
 app.use("/" + v2prefix + "/" + "address", addressV2.router);

--- a/dist/middleware/route-ratelimit.js
+++ b/dist/middleware/route-ratelimit.js
@@ -11,7 +11,8 @@ var routeRateLimit = function (req, res, next) {
         return next();
     // TODO: Auth: Set or disable rate limit if authenticated user
     // Current route
-    var route = req.baseUrl + req.path;
+    var path = req.baseUrl + req.path;
+    var route = path.split("/").slice(0, 4).join("/");
     // Create new RateLimit if none exists for this route
     if (!uniqueRateLimits[route]) {
         uniqueRateLimits[route] = new RateLimit({

--- a/dist/middleware/route-ratelimit.js
+++ b/dist/middleware/route-ratelimit.js
@@ -1,0 +1,35 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var RateLimit = require("express-rate-limit");
+// Set max requests per minute
+var maxRequests = process.env.RATE_LIMIT_MAX_REQUESTS ? parseInt(process.env.RATE_LIMIT_MAX_REQUESTS) : 60;
+// Unique route mapped to its rate limit
+var uniqueRateLimits = {};
+var routeRateLimit = function (req, res, next) {
+    // Disable rate limiting if 0 passed from RATE_LIMIT_MAX_REQUESTS
+    if (maxRequests === 0)
+        return next();
+    // TODO: Auth: Set or disable rate limit if authenticated user
+    // Current route
+    var route = req.baseUrl + req.path;
+    // Create new RateLimit if none exists for this route
+    if (!uniqueRateLimits[route]) {
+        uniqueRateLimits[route] = new RateLimit({
+            windowMs: 60 * 1000,
+            delayMs: 0,
+            max: maxRequests,
+            handler: function (req, res /*next*/) {
+                res.format({
+                    json: function () {
+                        res.status(500).json({
+                            error: "Too many requests. Limits are 60 requests per minute."
+                        });
+                    }
+                });
+            }
+        });
+    }
+    // Call rate limit for this route
+    uniqueRateLimits[route](req, res, next);
+};
+exports.routeRateLimit = routeRateLimit;

--- a/dist/public/bitcoin-com-mainnet-rest-v2.json
+++ b/dist/public/bitcoin-com-mainnet-rest-v2.json
@@ -1091,7 +1091,7 @@
 	"openapi": "3.0.0",
 	"info": {
 		"description": "rest.bitcoin.com is the REST layer for Bitcoin.com's Cloud. More info: [developer.bitcoin.com/rest](https://developer.bitcoin.com/rest). Chatroom [geni.us/CashDev](http://geni.us/CashDev)",
-		"version": "2.2.5",
+		"version": "2.2.6",
 		"title": "REST",
 		"license": {
 			"name": "MIT",

--- a/dist/public/bitcoin-com-testnet-rest-v2.json
+++ b/dist/public/bitcoin-com-testnet-rest-v2.json
@@ -1091,7 +1091,7 @@
 	"openapi": "3.0.0",
 	"info": {
 		"description": "trest.bitcoin.com is the REST layer for Bitcoin.com's Cloud. More info: [developer.bitcoin.com/rest](https://developer.bitcoin.com/rest). Chatroom [geni.us/CashDev](http://geni.us/CashDev)",
-		"version": "2.2.5",
+		"version": "2.2.6",
 		"title": "REST",
 		"license": {
 			"name": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rest.bitcoin.com",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest.bitcoin.com",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "REST API for Bitcoin.com's Cloud",
   "author": "Gabriel Cardona <gabriel@bitcoin.com>",
   "contributors": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,9 @@ import { Socket } from "net"
 
 import * as express from "express"
 
+// Middleware
+import { routeRateLimit } from "./middleware/route-ratelimit"
+
 const path = require("path")
 const logger = require("morgan")
 const cookieParser = require("cookie-parser")
@@ -130,6 +133,8 @@ app.use(`/${v1prefix}/` + `dataRetrieval`, dataRetrievalV1)
 app.use(`/${v1prefix}/` + `payloadCreation`, payloadCreationV1)
 app.use(`/${v1prefix}/` + `slp`, slpV1)
 
+// Rate limit on all v2 routes
+app.use(`/${v2prefix}/`, routeRateLimit)
 app.use("/", indexV2)
 app.use(`/${v2prefix}/` + `health-check`, healthCheckV2)
 app.use(`/${v2prefix}/` + `address`, addressV2.router)

--- a/src/middleware/route-ratelimit.ts
+++ b/src/middleware/route-ratelimit.ts
@@ -1,0 +1,47 @@
+import * as express from "express"
+const RateLimit = require("express-rate-limit")
+
+// Set max requests per minute
+const maxRequests = process.env.RATE_LIMIT_MAX_REQUESTS ? parseInt(process.env.RATE_LIMIT_MAX_REQUESTS) : 60
+
+// Unique route mapped to its rate limit
+const uniqueRateLimits: any = {}
+
+const routeRateLimit = function(
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) {
+  // Disable rate limiting if 0 passed from RATE_LIMIT_MAX_REQUESTS
+  if (maxRequests === 0) return next()
+
+  // TODO: Auth: Set or disable rate limit if authenticated user
+
+  // Current route
+  const route = req.baseUrl + req.path
+
+  // Create new RateLimit if none exists for this route
+  if (!uniqueRateLimits[route]) {
+    uniqueRateLimits[route] = new RateLimit({
+      windowMs: 60 * 1000, // 1 minute window
+      delayMs: 0, // disable delaying - full speed until the max limit is reached
+      max: maxRequests, // start blocking after maxRequests
+      handler: function(req: express.Request, res: express.Response /*next*/) {
+        res.format({
+          json: function() {
+            res.status(500).json({
+              error: "Too many requests. Limits are 60 requests per minute."
+            })
+          }
+        })
+      }
+    })
+  }
+
+  // Call rate limit for this route
+  uniqueRateLimits[route](req, res, next)
+}
+
+export {
+  routeRateLimit
+}

--- a/src/middleware/route-ratelimit.ts
+++ b/src/middleware/route-ratelimit.ts
@@ -18,7 +18,8 @@ const routeRateLimit = function(
   // TODO: Auth: Set or disable rate limit if authenticated user
 
   // Current route
-  const route = req.baseUrl + req.path
+  const path = req.baseUrl + req.path
+  const route = path.split("/").slice(0,4).join("/")
 
   // Create new RateLimit if none exists for this route
   if (!uniqueRateLimits[route]) {

--- a/src/routes/v2/address.ts
+++ b/src/routes/v2/address.ts
@@ -9,7 +9,6 @@ const routeUtils = require("./route-utils")
 
 //const router = express.Router()
 const router: express.Router = express.Router()
-const RateLimit = require("express-rate-limit")
 
 // Used for processing error messages before sending them to the user.
 const util = require("util")
@@ -25,66 +24,20 @@ const FREEMIUM_INPUT_SIZE = 20
 // https://github.com/bitpay/insight-api#notes-on-upgrading-from-v03
 const PAGE_SIZE = 1000
 
-interface IRLConfig {
-  [addressRateLimit1: string]: any
-  addressRateLimit2: any
-  addressRateLimit3: any
-  addressRateLimit4: any
-  addressRateLimit5: any
-  addressRateLimit6: any
-  addressRateLimit7: any
-  addressRateLimit8: any
-  addressRateLimit9: any
-  addressRateLimit10: any
-}
-
-const config: IRLConfig = {
-  addressRateLimit1: undefined,
-  addressRateLimit2: undefined,
-  addressRateLimit3: undefined,
-  addressRateLimit4: undefined,
-  addressRateLimit5: undefined,
-  addressRateLimit6: undefined,
-  addressRateLimit7: undefined,
-  addressRateLimit8: undefined,
-  addressRateLimit9: undefined,
-  addressRateLimit10: undefined
-}
-
-let i = 1
-while (i < 11) {
-  config[`addressRateLimit${i}`] = new RateLimit({
-    windowMs: 60000, // 1 hour window
-    delayMs: 0, // disable delaying - full speed until the max limit is reached
-    max: 60, // start blocking after 60 requests
-    handler: function(req: express.Request, res: express.Response /*next*/) {
-      res.format({
-        json: function() {
-          res.status(500).json({
-            error: "Too many requests. Limits are 60 requests per minute."
-          })
-        }
-      })
-    }
-  })
-  i++
-}
-
 // Connect the route endpoints to their handler functions.
-router.get("/", config.addressRateLimit1, root)
-router.get("/details/:address", config.addressRateLimit2, detailsSingle)
-router.post("/details", config.addressRateLimit3, detailsBulk)
-router.post("/utxo", config.addressRateLimit4, utxoBulk)
-router.get("/utxo/:address", config.addressRateLimit5, utxoSingle)
-router.post("/unconfirmed", config.addressRateLimit6, unconfirmedBulk)
-router.get("/unconfirmed/:address", config.addressRateLimit7, unconfirmedSingle)
+router.get("/", root)
+router.get("/details/:address", detailsSingle)
+router.post("/details", detailsBulk)
+router.post("/utxo", utxoBulk)
+router.get("/utxo/:address", utxoSingle)
+router.post("/unconfirmed", unconfirmedBulk)
+router.get("/unconfirmed/:address", unconfirmedSingle)
 router.get(
   "/transactions/:address",
-  config.addressRateLimit8,
   transactionsSingle
 )
-router.post("/transactions", config.addressRateLimit9, transactionsBulk)
-router.get("/fromXPub/:xpub", config.addressRateLimit10, fromXPubSingle)
+router.post("/transactions", transactionsBulk)
+router.get("/fromXPub/:xpub", fromXPubSingle)
 
 // Root API endpoint. Simply acknowledges that it exists.
 function root(

--- a/src/routes/v2/block.ts
+++ b/src/routes/v2/block.ts
@@ -16,52 +16,14 @@ const router: express.Router = express.Router()
 
 const FREEMIUM_INPUT_SIZE = 20
 
-const RateLimit = require("express-rate-limit")
-
-interface IRLConfig {
-  [blockRateLimit1: string]: any
-  blockRateLimit2: any
-  blockRateLimit3: any
-  blockRateLimit4: any
-  blockRateLimit5: any
-}
-
-const config: IRLConfig = {
-  blockRateLimit1: undefined,
-  blockRateLimit2: undefined,
-  blockRateLimit3: undefined,
-  blockRateLimit4: undefined,
-  blockRateLimit5: undefined
-}
-
-let i = 1
-while (i < 6) {
-  config[`blockRateLimit${i}`] = new RateLimit({
-    windowMs: 60000, // 1 hour window
-    delayMs: 0, // disable delaying - full speed until the max limit is reached
-    max: 60, // start blocking after 60 requests
-    handler: (req: express.Request, res: express.Response /*next*/) => {
-      res.format({
-        json: () => {
-          res.status(500).json({
-            error: "Too many requests. Limits are 60 requests per minute."
-          })
-        }
-      })
-    }
-  })
-  i++
-}
-
-router.get("/", config.blockRateLimit1, root)
-router.get("/detailsByHash/:hash", config.blockRateLimit2, detailsByHashSingle)
-router.post("/detailsByHash", config.blockRateLimit3, detailsByHashBulk)
+router.get("/", root)
+router.get("/detailsByHash/:hash", detailsByHashSingle)
+router.post("/detailsByHash", detailsByHashBulk)
 router.get(
   "/detailsByHeight/:height",
-  config.blockRateLimit4,
   detailsByHeightSingle
 )
-router.post("/detailsByHeight", config.blockRateLimit5, detailsByHeightBulk)
+router.post("/detailsByHeight", detailsByHeightBulk)
 
 function root(
   req: express.Request,

--- a/src/routes/v2/blockchain.ts
+++ b/src/routes/v2/blockchain.ts
@@ -9,7 +9,6 @@ import * as express from "express"
 const router = express.Router()
 import axios from "axios"
 import { IRequestConfig } from "./interfaces/IRequestConfig"
-const RateLimit = require("express-rate-limit")
 const routeUtils = require("./route-utils")
 const logger = require("./logging.js")
 
@@ -19,108 +18,43 @@ util.inspect.defaultOptions = { depth: 1 }
 
 const FREEMIUM_INPUT_SIZE = 20
 
-interface IRLConfig {
-  [blockchainRateLimit1: string]: any
-  blockchainRateLimit2: any
-  blockchainRateLimit3: any
-  blockchainRateLimit4: any
-  blockchainRateLimit5: any
-  blockchainRateLimit6: any
-  blockchainRateLimit7: any
-  blockchainRateLimit8: any
-  blockchainRateLimit9: any
-  blockchainRateLimit10: any
-  blockchainRateLimit11: any
-  blockchainRateLimit12: any
-  blockchainRateLimit13: any
-  blockchainRateLimit14: any
-  blockchainRateLimit15: any
-  blockchainRateLimit16: any
-  blockchainRateLimit17: any
-}
-
-const config: IRLConfig = {
-  blockchainRateLimit1: undefined,
-  blockchainRateLimit2: undefined,
-  blockchainRateLimit3: undefined,
-  blockchainRateLimit4: undefined,
-  blockchainRateLimit5: undefined,
-  blockchainRateLimit6: undefined,
-  blockchainRateLimit7: undefined,
-  blockchainRateLimit8: undefined,
-  blockchainRateLimit9: undefined,
-  blockchainRateLimit10: undefined,
-  blockchainRateLimit11: undefined,
-  blockchainRateLimit12: undefined,
-  blockchainRateLimit13: undefined,
-  blockchainRateLimit14: undefined,
-  blockchainRateLimit15: undefined,
-  blockchainRateLimit16: undefined,
-  blockchainRateLimit17: undefined
-}
-
-let i = 1
-while (i < 18) {
-  config[`blockchainRateLimit${i}`] = new RateLimit({
-    windowMs: 60000, // 1 hour window
-    delayMs: 0, // disable delaying - full speed until the max limit is reached
-    max: 60, // start blocking after 60 requests
-    handler: (req: express.Request, res: express.Response /*next*/) => {
-      res.format({
-        json: () => {
-          res.status(500).json({
-            error: "Too many requests. Limits are 60 requests per minute."
-          })
-        }
-      })
-    }
-  })
-  i++
-}
-
 // Define routes.
-router.get("/", config.blockchainRateLimit1, root)
-router.get("/getBestBlockHash", config.blockchainRateLimit2, getBestBlockHash)
+router.get("/", root)
+router.get("/getBestBlockHash", getBestBlockHash)
 // Dev Note: getBlock/:hash ommited because its the same as block/detailsByHash
-//router.get("/getBlock/:hash", config.blockchainRateLimit3, getBlock)
-router.get("/getBlockchainInfo", config.blockchainRateLimit3, getBlockchainInfo)
-router.get("/getBlockCount", config.blockchainRateLimit4, getBlockCount)
+//router.get("/getBlock/:hash", getBlock)
+router.get("/getBlockchainInfo", getBlockchainInfo)
+router.get("/getBlockCount", getBlockCount)
 router.get(
   "/getBlockHeader/:hash",
-  config.blockchainRateLimit5,
   getBlockHeaderSingle
 )
-router.post("/getBlockHeader", config.blockchainRateLimit6, getBlockHeaderBulk)
+router.post("/getBlockHeader", getBlockHeaderBulk)
 
-router.get("/getChainTips", config.blockchainRateLimit7, getChainTips)
-router.get("/getDifficulty", config.blockchainRateLimit8, getDifficulty)
+router.get("/getChainTips", getChainTips)
+router.get("/getDifficulty", getDifficulty)
 router.get(
   "/getMempoolEntry/:txid",
-  config.blockchainRateLimit9,
   getMempoolEntrySingle
 )
 router.post(
   "/getMempoolEntry",
-  config.blockchainRateLimit10,
   getMempoolEntryBulk
 )
-router.get("/getMempoolInfo", config.blockchainRateLimit11, getMempoolInfo)
-router.get("/getRawMempool", config.blockchainRateLimit12, getRawMempool)
-router.get("/getTxOut/:txid/:n", config.blockchainRateLimit13, getTxOut)
+router.get("/getMempoolInfo", getMempoolInfo)
+router.get("/getRawMempool", getRawMempool)
+router.get("/getTxOut/:txid/:n", getTxOut)
 router.get(
   "/getTxOutProof/:txid",
-  config.blockchainRateLimit14,
   getTxOutProofSingle
 )
-router.post("/getTxOutProof", config.blockchainRateLimit15, getTxOutProofBulk)
+router.post("/getTxOutProof", getTxOutProofBulk)
 router.get(
   "/verifyTxOutProof/:proof",
-  config.blockchainRateLimit16,
   verifyTxOutProofSingle
 )
 router.post(
   "/verifyTxOutProof",
-  config.blockchainRateLimit17,
   verifyTxOutProofBulk
 )
 

--- a/src/routes/v2/control.ts
+++ b/src/routes/v2/control.ts
@@ -4,7 +4,6 @@ import * as express from "express"
 const router = express.Router()
 import axios from "axios"
 import { IRequestConfig } from "./interfaces/IRequestConfig"
-const RateLimit = require("express-rate-limit")
 const logger = require("./logging.js")
 const routeUtils = require("./route-utils")
 
@@ -12,39 +11,8 @@ const routeUtils = require("./route-utils")
 const util = require("util")
 util.inspect.defaultOptions = { depth: 1 }
 
-// Typescript
-interface IRLConfig {
-  [controlRateLimit1: string]: any
-  controlRateLimit2: any
-}
-
-// Typescript
-const config: IRLConfig = {
-  controlRateLimit1: undefined,
-  controlRateLimit2: undefined
-}
-
-let i = 1
-while (i < 3) {
-  config[`controlRateLimit${i}`] = new RateLimit({
-    windowMs: 60000, // 1 hour window
-    delayMs: 0, // disable delaying - full speed until the max limit is reached
-    max: 60, // start blocking after 60 requests
-    handler: (req: express.Request, res: express.Response /*next*/) => {
-      res.format({
-        json: () => {
-          res.status(500).json({
-            error: "Too many requests. Limits are 60 requests per minute."
-          })
-        }
-      })
-    }
-  })
-  i++
-}
-
-router.get("/", config.controlRateLimit1, root)
-router.get("/getInfo", config.controlRateLimit2, getInfo)
+router.get("/", root)
+router.get("/getInfo", getInfo)
 
 function root(
   req: express.Request,

--- a/src/routes/v2/generating.js
+++ b/src/routes/v2/generating.js
@@ -3,7 +3,6 @@
 const express = require("express")
 const router = express.Router()
 //const axios = require("axios");
-const RateLimit = require("express-rate-limit")
 
 //const BITBOXCli = require("bitbox-sdk/lib/bitbox-sdk").default;
 //const BITBOX = new BITBOXCli();
@@ -14,30 +13,7 @@ const RateLimit = require("express-rate-limit")
 //const username = process.env.RPC_USERNAME;
 //const password = process.env.RPC_PASSWORD;
 
-const config = {
-  generatingRateLimit1: undefined
-}
-
-let i = 1
-while (i < 2) {
-  config[`generatingRateLimit${i}`] = new RateLimit({
-    windowMs: 60000, // 1 hour window
-    delayMs: 0, // disable delaying - full speed until the max limit is reached
-    max: 60, // start blocking after 60 requests
-    handler: function(req, res /*next*/) {
-      res.format({
-        json: function() {
-          res.status(500).json({
-            error: "Too many requests. Limits are 60 requests per minute."
-          })
-        }
-      })
-    }
-  })
-  i++
-}
-
-router.get("/", config.generatingRateLimit1, (req, res, next) => {
+router.get("/", (req, res, next) => {
   res.json({ status: "generating" })
 })
 //

--- a/src/routes/v2/health-check.js
+++ b/src/routes/v2/health-check.js
@@ -2,25 +2,9 @@
 
 const express = require("express")
 const router = express.Router()
-const RateLimit = require("express-rate-limit")
-
-const healthCheckRateLimit = new RateLimit({
-  windowMs: 60000, // 1 hour window
-  delayMs: 0, // disable delaying - full speed until the max limit is reached
-  max: 60, // start blocking after 60 requests
-  handler: function(req, res /*next*/) {
-    res.format({
-      json: function() {
-        res.status(500).json({
-          error: "Too many requests. Limits are 60 requests per minute."
-        })
-      }
-    })
-  }
-})
 
 /* GET home page. */
-router.get("/", healthCheckRateLimit, (req, res, next) => {
+router.get("/", (req, res, next) => {
   res.json({ status: "winning v2" })
 })
 

--- a/src/routes/v2/index.js
+++ b/src/routes/v2/index.js
@@ -2,44 +2,13 @@
 
 const express = require("express")
 const router = express.Router()
-const RateLimit = require("express-rate-limit")
-
-const indexRateLimit1 = new RateLimit({
-  windowMs: 60 * 60 * 1000, // 1 hour window
-  delayMs: 0, // disable delaying - full speed until the max limit is reached
-  max: 60, // start blocking after 60 requests
-  handler: function(req, res /*next*/) {
-    res.format({
-      json: function() {
-        res.status(500).json({
-          error: "Too many requests. Limits are 60 requests per minute."
-        })
-      }
-    })
-  }
-})
-
-const indexRateLimit2 = new RateLimit({
-  windowMs: 60 * 60 * 1000, // 1 hour window
-  delayMs: 0, // disable delaying - full speed until the max limit is reached
-  max: 60, // start blocking after 60 requests
-  handler: function(req, res /*next*/) {
-    res.format({
-      json: function() {
-        res.status(500).json({
-          error: "Too many requests. Limits are 60 requests per minute."
-        })
-      }
-    })
-  }
-})
 
 /* GET home page. */
-router.get("/", indexRateLimit1, (req, res, next) => {
+router.get("/", (req, res, next) => {
   res.render("swagger-v2")
 })
 
-router.get("/v2", indexRateLimit2, (req, res, next) => {
+router.get("/v2", (req, res, next) => {
   res.render("swagger-v2")
 })
 

--- a/src/routes/v2/mining.ts
+++ b/src/routes/v2/mining.ts
@@ -4,7 +4,6 @@ import * as express from "express"
 const router = express.Router()
 import axios from "axios"
 import { IRequestConfig } from "./interfaces/IRequestConfig"
-const RateLimit = require("express-rate-limit")
 const routeUtils = require("./route-utils")
 const logger = require("./logging.js")
 
@@ -29,40 +28,9 @@ const requestConfig: IRequestConfig = {
   }
 }
 
-interface IRLConfig {
-  [miningRateLimit1: string]: any
-  miningRateLimit2: any
-  miningRateLimit3: any
-}
-
-const config: IRLConfig = {
-  miningRateLimit1: undefined,
-  miningRateLimit2: undefined,
-  miningRateLimit3: undefined
-}
-
-let i = 1
-while (i < 4) {
-  config[`miningRateLimit${i}`] = new RateLimit({
-    windowMs: 60000, // 1 hour window
-    delayMs: 0, // disable delaying - full speed until the max limit is reached
-    max: 60, // start blocking after 60 requests
-    handler: (req: express.Request, res: express.Response /*next*/) => {
-      res.format({
-        json: () => {
-          res.status(500).json({
-            error: "Too many requests. Limits are 60 requests per minute."
-          })
-        }
-      })
-    }
-  })
-  i++
-}
-
-router.get("/", config.miningRateLimit1, root)
-router.get("/getMiningInfo", config.miningRateLimit2, getMiningInfo)
-router.get("/getNetworkHashps", config.miningRateLimit3, getNetworkHashPS)
+router.get("/", root)
+router.get("/getMiningInfo", getMiningInfo)
+router.get("/getNetworkHashps", getNetworkHashPS)
 
 function root(
   req: express.Request,

--- a/src/routes/v2/network.ts
+++ b/src/routes/v2/network.ts
@@ -2,38 +2,9 @@
 
 import * as express from "express"
 const router = express.Router()
-const RateLimit = require("express-rate-limit")
-
-interface IRLConfig {
-  [networkRateLimit1: string]: any
-}
-
-const config: IRLConfig = {
-  networkRateLimit1: undefined
-}
-
-let i = 1
-while (i < 2) {
-  config[`networkRateLimit${i}`] = new RateLimit({
-    windowMs: 60000, // 1 hour window
-    delayMs: 0, // disable delaying - full speed until the max limit is reached
-    max: 60, // start blocking after 60 requests
-    handler: (req: express.Request, res: express.Response /*next*/) => {
-      res.format({
-        json: () => {
-          res.status(500).json({
-            error: "Too many requests. Limits are 60 requests per minute."
-          })
-        }
-      })
-    }
-  })
-  i++
-}
 
 router.get(
   "/",
-  config.networkRateLimit1,
   async (
     req: express.Request,
     res: express.Response,

--- a/src/routes/v2/rawtransactions.ts
+++ b/src/routes/v2/rawtransactions.ts
@@ -5,7 +5,6 @@ const router = express.Router()
 import axios from "axios"
 import { IRequestConfig } from "./interfaces/IRequestConfig"
 import { IResponse } from "./interfaces/IResponse"
-const RateLimit = require("express-rate-limit")
 const routeUtils = require("./route-utils")
 const logger = require("./logging.js")
 
@@ -32,69 +31,26 @@ const requestConfig: IRequestConfig = {
   }
 }
 
-interface IRLConfig {
-  [rawTransactionsRateLimit1: string]: any
-  rawTransactionsRateLimit2: any
-  rawTransactionsRateLimit3: any
-  rawTransactionsRateLimit4: any
-  rawTransactionsRateLimit5: any
-  rawTransactionsRateLimit6: any
-}
-
-const config: IRLConfig = {
-  rawTransactionsRateLimit1: undefined,
-  rawTransactionsRateLimit2: undefined,
-  rawTransactionsRateLimit3: undefined,
-  rawTransactionsRateLimit4: undefined,
-  rawTransactionsRateLimit5: undefined,
-  rawTransactionsRateLimit6: undefined
-}
-
-let i = 1
-
-while (i < 7) {
-  config[`rawTransactionsRateLimit${i}`] = new RateLimit({
-    windowMs: 60000, // 1 hour window
-    delayMs: 0, // disable delaying - full speed until the max limit is reached
-    max: 60, // start blocking after 60 requests
-    handler: (req: express.Request, res: express.Response /*next*/) => {
-      res.format({
-        json: () => {
-          res.status(500).json({
-            error: "Too many requests. Limits are 60 requests per minute."
-          })
-        }
-      })
-    }
-  })
-  i++
-}
-
-router.get("/", config.rawTransactionsRateLimit1, root)
+router.get("/", root)
 router.get(
   "/decodeRawTransaction/:hex",
-  config.rawTransactionsRateLimit2,
   decodeRawTransactionSingle
 )
 router.post(
   "/decodeRawTransaction",
-  config.rawTransactionsRateLimit2,
   decodeRawTransactionBulk
 )
-router.get("/decodeScript/:hex", config.rawTransactionsRateLimit3, decodeScript)
+router.get("/decodeScript/:hex", decodeScript)
 router.post(
   "/getRawTransaction",
-  config.rawTransactionsRateLimit4,
   getRawTransactionBulk
 )
 router.get(
   "/getRawTransaction/:txid",
-  config.rawTransactionsRateLimit5,
   getRawTransactionSingle
 )
 router.post(
   "/sendRawTransaction",
-  config.rawTransactionsRateLimit6,
   sendRawTransaction
 )
 

--- a/src/routes/v2/slp.ts
+++ b/src/routes/v2/slp.ts
@@ -4,7 +4,6 @@ import * as express from "express"
 const router = express.Router()
 import axios from "axios"
 import { IRequestConfig } from "./interfaces/IRequestConfig"
-const RateLimit = require("express-rate-limit")
 const routeUtils = require("./route-utils")
 const logger = require("./logging.js")
 const strftime = require("strftime")
@@ -124,60 +123,19 @@ const requestConfig: IRequestConfig = {
   }
 }
 
-interface IRLConfig {
-  [slpRateLimit1: string]: any
-  slpRateLimit2: any
-  slpRateLimit3: any
-  slpRateLimit4: any
-  slpRateLimit5: any
-  slpRateLimit6: any
-  slpRateLimit7: any
-}
-
-const config: IRLConfig = {
-  slpRateLimit1: undefined,
-  slpRateLimit2: undefined,
-  slpRateLimit3: undefined,
-  slpRateLimit4: undefined,
-  slpRateLimit5: undefined,
-  slpRateLimit6: undefined,
-  slpRateLimit7: undefined
-}
-
-let i = 1
-while (i < 8) {
-  config[`slpRateLimit${i}`] = new RateLimit({
-    windowMs: 60000, // 1 hour window
-    delayMs: 0, // disable delaying - full speed until the max limit is reached
-    max: 60, // start blocking after 60 requests
-    handler: (req: express.Request, res: express.Response /*next*/) => {
-      res.format({
-        json: () => {
-          res.status(500).json({
-            error: "Too many requests. Limits are 60 requests per minute."
-          })
-        }
-      })
-    }
-  })
-  i++
-}
-
-router.get("/", config.slpRateLimit1, root)
-router.get("/list", config.slpRateLimit2, list)
-router.get("/list/:tokenId", config.slpRateLimit3, listSingleToken)
+router.get("/", root)
+router.get("/list", list)
+router.get("/list/:tokenId", listSingleToken)
 router.get(
   "/balancesForAddress/:address",
-  config.slpRateLimit4,
   balancesForAddress
 )
 router.get(
   "/balance/:address/:tokenId",
-  config.slpRateLimit5,
   balancesForAddressByTokenID
 )
-router.get("/address/convert/:address", config.slpRateLimit6, convertAddress)
-router.post("/validateTxid", config.slpRateLimit7, validateBulk)
+router.get("/address/convert/:address", convertAddress)
+router.post("/validateTxid", validateBulk)
 
 function root(
   req: express.Request,

--- a/src/routes/v2/util.ts
+++ b/src/routes/v2/util.ts
@@ -4,7 +4,6 @@ import * as express from "express"
 const router = express.Router()
 import axios from "axios"
 import { IRequestConfig } from "./interfaces/IRequestConfig"
-const RateLimit = require("express-rate-limit")
 const routeUtils = require("./route-utils")
 const logger = require("./logging.js")
 
@@ -35,44 +34,12 @@ const requestConfig: IRequestConfig = {
   }
 }
 
-interface IRLConfig {
-  [utilRateLimit1: string]: any
-  utilRateLimit2: any
-  utilRateLimit3: any
-}
-
-const config: IRLConfig = {
-  utilRateLimit1: undefined,
-  utilRateLimit2: undefined,
-  utilRateLimit3: undefined
-}
-
-let i = 1
-while (i < 4) {
-  config[`utilRateLimit${i}`] = new RateLimit({
-    windowMs: 60000, // 1 hour window
-    delayMs: 0, // disable delaying - full speed until the max limit is reached
-    max: 60, // start blocking after 60 requests
-    handler: (req: express.Request, res: express.Response /*next*/) => {
-      res.format({
-        json: () => {
-          res.status(500).json({
-            error: "Too many requests. Limits are 60 requests per minute."
-          })
-        }
-      })
-    }
-  })
-  i++
-}
-
-router.get("/", config.utilRateLimit1, root)
+router.get("/", root)
 router.get(
   "/validateAddress/:address",
-  config.utilRateLimit2,
   validateAddressSingle
 )
-router.post("/validateAddress", config.utilRateLimit3, validateAddressBulk)
+router.post("/validateAddress", validateAddressBulk)
 
 function root(
   req: express.Request,

--- a/swaggerJSONFiles/info.json
+++ b/swaggerJSONFiles/info.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "description": "The Bitcoin Cash JSON PRC over HTTP",
-    "version": "2.2.5",
+    "version": "2.2.6",
     "title": "REST",
     "license": {
       "name": "MIT",

--- a/swaggerJSONFilesBuilt/mainnet/info.json
+++ b/swaggerJSONFilesBuilt/mainnet/info.json
@@ -2,7 +2,7 @@
 	"openapi": "3.0.0",
 	"info": {
 		"description": "rest.bitcoin.com is the REST layer for Bitcoin.com's Cloud. More info: [developer.bitcoin.com/rest](https://developer.bitcoin.com/rest). Chatroom [geni.us/CashDev](http://geni.us/CashDev)",
-		"version": "2.2.5",
+		"version": "2.2.6",
 		"title": "REST",
 		"license": {
 			"name": "MIT",

--- a/swaggerJSONFilesBuilt/testnet/info.json
+++ b/swaggerJSONFilesBuilt/testnet/info.json
@@ -2,7 +2,7 @@
 	"openapi": "3.0.0",
 	"info": {
 		"description": "trest.bitcoin.com is the REST layer for Bitcoin.com's Cloud. More info: [developer.bitcoin.com/rest](https://developer.bitcoin.com/rest). Chatroom [geni.us/CashDev](http://geni.us/CashDev)",
-		"version": "2.2.5",
+		"version": "2.2.6",
 		"title": "REST",
 		"license": {
 			"name": "MIT",


### PR DESCRIPTION
Only changes /v2 routes

Default rate limit is 60

Rate limit can be specified with env var RATE_LIMIT_MAX_REQUESTS
Setting RATE_LIMIT_MAX_REQUESTS=0 will disable rate limiting on v2 routes