### PR TITLE
fix(sendRawTransaction): Adding GET /rawTransactions/sendRawTransaction/:hex endpoint

### DIFF
--- a/dist/public/bitcoin-com-mainnet-rest-v2.json
+++ b/dist/public/bitcoin-com-mainnet-rest-v2.json
@@ -1091,7 +1091,7 @@
 	"openapi": "3.0.0",
 	"info": {
 		"description": "rest.bitcoin.com is the REST layer for Bitcoin.com's Cloud. More info: [developer.bitcoin.com/rest](https://developer.bitcoin.com/rest). Chatroom [geni.us/CashDev](http://geni.us/CashDev)",
-		"version": "2.2.6",
+		"version": "2.2.7",
 		"title": "REST",
 		"license": {
 			"name": "MIT",

--- a/dist/public/bitcoin-com-testnet-rest-v2.json
+++ b/dist/public/bitcoin-com-testnet-rest-v2.json
@@ -1091,7 +1091,7 @@
 	"openapi": "3.0.0",
 	"info": {
 		"description": "trest.bitcoin.com is the REST layer for Bitcoin.com's Cloud. More info: [developer.bitcoin.com/rest](https://developer.bitcoin.com/rest). Chatroom [geni.us/CashDev](http://geni.us/CashDev)",
-		"version": "2.2.6",
+		"version": "2.2.7",
 		"title": "REST",
 		"license": {
 			"name": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest.bitcoin.com",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "REST API for Bitcoin.com's Cloud",
   "author": "Gabriel Cardona <gabriel@bitcoin.com>",
   "contributors": [

--- a/src/routes/v2/rawtransactions.ts
+++ b/src/routes/v2/rawtransactions.ts
@@ -388,12 +388,11 @@ async function sendRawTransactionBulk(
   try {
     // Validation
     const hexes = req.body.hexes // Body
-    const hex = req.params.hex // URL parameter
 
     // Reject if input is not an array or a string
-    if (!Array.isArray(hexes) || typeof hex === "string") {
+    if (!Array.isArray(hexes)) {
       res.status(400)
-      return res.json({ error: "hex must be an array or string" })
+      return res.json({ error: "hex must be an array" })
     }
 
     const {
@@ -486,6 +485,12 @@ async function sendRawTransactionSingle(
   try {
     const hex = req.params.hex // URL parameter
 
+    // Reject if input is not an array or a string
+    if (typeof hex !== "string") {
+      res.status(400)
+      return res.json({ error: "hex must be a string" })
+    }
+
     // Validation
     if (hex === "") {
       res.status(400)
@@ -493,6 +498,13 @@ async function sendRawTransactionSingle(
         error: `Encountered empty hex`
       })
     }
+
+    const {
+      BitboxHTTP,
+      username,
+      password,
+      requestConfig
+    } = routeUtils.setEnvVars()
 
     // RPC call
     requestConfig.data.id = "sendrawtransaction"

--- a/src/routes/v2/rawtransactions.ts
+++ b/src/routes/v2/rawtransactions.ts
@@ -387,9 +387,9 @@ async function sendRawTransactionBulk(
 ) {
   try {
     // Validation
-    const hexes = req.body.hexes // Body
+    const hexes = req.body.hexes
 
-    // Reject if input is not an array or a string
+    // Reject if input is not an array
     if (!Array.isArray(hexes)) {
       res.status(400)
       return res.json({ error: "hex must be an array" })

--- a/swaggerJSONFiles/info.json
+++ b/swaggerJSONFiles/info.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "description": "The Bitcoin Cash JSON PRC over HTTP",
-    "version": "2.2.6",
+    "version": "2.2.7",
     "title": "REST",
     "license": {
       "name": "MIT",

--- a/swaggerJSONFilesBuilt/mainnet/info.json
+++ b/swaggerJSONFilesBuilt/mainnet/info.json
@@ -2,7 +2,7 @@
 	"openapi": "3.0.0",
 	"info": {
 		"description": "rest.bitcoin.com is the REST layer for Bitcoin.com's Cloud. More info: [developer.bitcoin.com/rest](https://developer.bitcoin.com/rest). Chatroom [geni.us/CashDev](http://geni.us/CashDev)",
-		"version": "2.2.6",
+		"version": "2.2.7",
 		"title": "REST",
 		"license": {
 			"name": "MIT",

--- a/swaggerJSONFilesBuilt/testnet/info.json
+++ b/swaggerJSONFilesBuilt/testnet/info.json
@@ -2,7 +2,7 @@
 	"openapi": "3.0.0",
 	"info": {
 		"description": "trest.bitcoin.com is the REST layer for Bitcoin.com's Cloud. More info: [developer.bitcoin.com/rest](https://developer.bitcoin.com/rest). Chatroom [geni.us/CashDev](http://geni.us/CashDev)",
-		"version": "2.2.6",
+		"version": "2.2.7",
 		"title": "REST",
 		"license": {
 			"name": "MIT",

--- a/test/v2/raw-transactions.js
+++ b/test/v2/raw-transactions.js
@@ -512,10 +512,9 @@ describe("#Raw-Transactions", () => {
     })
   })
 
-  describe("sendRawTransaction()", () => {
-    // block route handler.
+  describe("sendRawTransactionBulk()", () => {
     const sendRawTransaction =
-      rawtransactions.testableComponents.sendRawTransaction
+      rawtransactions.testableComponents.sendRawTransactionBulk
 
     it("should throw 400 error if hexs array is missing", async () => {
       const result = await sendRawTransaction(req, res)
@@ -593,6 +592,114 @@ describe("#Raw-Transactions", () => {
       if (process.env.TEST === "unit") {
         assert.isArray(result)
         assert.isString(result[0])
+
+        // Integration test
+      } else {
+        assert.hasAllKeys(result, ["error"])
+        assert.include(result.error, "transaction already in block chain")
+      }
+    })
+  })
+
+  describe("sendRawTransactionSingle()", () => {
+    // block route handler.
+    const sendRawTransaction =
+      rawtransactions.testableComponents.sendRawTransactionSingle
+
+    it("should throw an error for an empty hex", async () => {
+      req.params.hex = ""
+
+      const result = await sendRawTransaction(req, res)
+
+      assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
+      assert.include(
+        result.error,
+        "Encountered empty hex",
+        "Proper error message"
+      )
+    })
+
+    it("should throw an error for a non-string", async () => {
+      req.params.hex = 456
+
+      const result = await sendRawTransaction(req, res)
+
+      assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
+      assert.include(
+        result.error,
+        "hex must be a string",
+        "Proper error message"
+      )
+    })
+
+    it("should throw 500 when network issues", async () => {
+      // Save the existing RPC URL.
+      const savedUrl = process.env.BITCOINCOM_BASEURL
+      const savedUrl2 = process.env.RPC_BASEURL
+
+      // Manipulate the URL to cause a 500 network error.
+      process.env.BITCOINCOM_BASEURL = "http://fakeurl/api/"
+      process.env.RPC_BASEURL = "http://fakeurl/api/"
+
+      req.params.hex =
+        "0200000001189f7cf4303e2e0bcc5af4be323b9b397dd4104ca2de09528eb90a1450b8a999010000006a4730440220212ec2ffce136a30cec1bc86a40b08a2afdeb6f8dbd652d7bcb07b1aad6dfa8c022041f59585273b89d88879a9a531ba3272dc953f48ff57dad955b2dee70e76c0624121030143ffd18f1c4add75c86b2f930d9551d51f7a6bd786314247022b7afc45d231ffffffff0230d39700000000001976a914af64a026e06910c59463b000d18c3d125d7e951a88ac58c20000000000001976a914af64a026e06910c59463b000d18c3d125d7e951a88ac00000000"
+      const result = await sendRawTransaction(req, res)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      // Restore the saved URL.
+      process.env.BITCOINCOM_BASEURL = savedUrl
+      process.env.RPC_BASEURL = savedUrl2
+
+      assert.isAbove(
+        res.statusCode,
+        499,
+        "HTTP status code 500 or great expected."
+      )
+    })
+
+    it("should throw an error for invalid hex", async () => {
+      req.params.hex = "abc123"
+
+      // Mock the RPC call for unit tests.
+      if (process.env.TEST === "unit") {
+        nock(`${process.env.RPC_BASEURL}`)
+          .post(``)
+          .reply(500, {
+            error: { message: "TX decode failed" }
+          })
+      }
+
+      const result = await sendRawTransaction(req, res)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      assert.hasAllKeys(result, ["error"])
+      assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
+      assert.include(result.error, "TX decode failed")
+    })
+
+    it("should GET /sendRawTransaction/:hex", async () => {
+      // This is a difficult test to run as transaction hex is invalid after a
+      // block confirmation. So the unit tests simulates what the output 'should'
+      // be, but the integration asserts an expected failure.
+
+      // Mock the RPC call for unit tests.
+      if (process.env.TEST === "unit") {
+        nock(`${process.env.RPC_BASEURL}`)
+          .post(``)
+          .reply(200, {
+            result:
+              "aef8848396e67532b42008b9d75b5a5a3459a6717740f31f0553b74102b4b118"
+          })
+      }
+
+      req.params.hex =
+        "0200000001189f7cf4303e2e0bcc5af4be323b9b397dd4104ca2de09528eb90a1450b8a999010000006a4730440220212ec2ffce136a30cec1bc86a40b08a2afdeb6f8dbd652d7bcb07b1aad6dfa8c022041f59585273b89d88879a9a531ba3272dc953f48ff57dad955b2dee70e76c0624121030143ffd18f1c4add75c86b2f930d9551d51f7a6bd786314247022b7afc45d231ffffffff0230d39700000000001976a914af64a026e06910c59463b000d18c3d125d7e951a88ac58c20000000000001976a914af64a026e06910c59463b000d18c3d125d7e951a88ac00000000"
+
+      const result = await sendRawTransaction(req, res)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      if (process.env.TEST === "unit") {
+        assert.isString(result)
 
         // Integration test
       } else {


### PR DESCRIPTION
This PR addresses Issue #273 by adding a GET call for the `/rawTransactions/sendRawTransaction/:hex` endpoint. The behavior of the POST endpoint remains unchanged. This PR adds unit and integration tests for the new endpoint.