### PR TITLE
SLP bulk list by ID

### DIFF
--- a/dist/public/bitcoin-com-mainnet-rest-v2.json
+++ b/dist/public/bitcoin-com-mainnet-rest-v2.json
@@ -137,6 +137,18 @@
 					}
 				}
 			},
+			"SLPListBulk": {
+				"type": "object",
+				"properties": {
+					"tokenIds": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/SLPListBulk"
+						},
+						"example": []
+					}
+				}
+			},
 			"SLPTxids": {
 				"type": "object",
 				"properties": {
@@ -2659,13 +2671,24 @@
 			}
 		},
 		"/slp/list": {
-			"get": {
+			"post": {
 				"tags": [
 					"slp"
 				],
-				"summary": "list",
-				"description": "List all SLP tokens",
-				"operationId": "listAll",
+				"summary": "list token information",
+				"description": "List multiple SLP tokens by id",
+				"operationId": "listBulk",
+				"requestBody": {
+					"description": "",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/SLPListBulk"
+							}
+						}
+					}
+				},
 				"responses": {
 					"200": {
 						"description": "successful response"

--- a/dist/public/bitcoin-com-testnet-rest-v2.json
+++ b/dist/public/bitcoin-com-testnet-rest-v2.json
@@ -137,6 +137,18 @@
 					}
 				}
 			},
+			"SLPListBulk": {
+				"type": "object",
+				"properties": {
+					"tokenIds": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/SLPListBulk"
+						},
+						"example": []
+					}
+				}
+			},
 			"SLPTxids": {
 				"type": "object",
 				"properties": {
@@ -2659,13 +2671,24 @@
 			}
 		},
 		"/slp/list": {
-			"get": {
+			"post": {
 				"tags": [
 					"slp"
 				],
-				"summary": "list",
-				"description": "List all SLP tokens",
-				"operationId": "listAll",
+				"summary": "list token information",
+				"description": "List multiple SLP tokens by id",
+				"operationId": "listBulk",
+				"requestBody": {
+					"description": "",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/SLPListBulk"
+							}
+						}
+					}
+				},
 				"responses": {
 					"200": {
 						"description": "successful response"

--- a/src/routes/v2/slp.ts
+++ b/src/routes/v2/slp.ts
@@ -238,82 +238,7 @@ async function listSingleToken(
     }
 
     const t = await lookupToken(tokenId)
-/*
-    const query = {
-      v: 3,
-      q: {
-        find: { "out.h1": "534c5000", "out.s3": "GENESIS" },
-        limit: 1000
-      }
-    }
 
-    const s = JSON.stringify(query)
-    const b64 = Buffer.from(s).toString("base64")
-    const url = `${process.env.BITDB_URL}q/${b64}`
-
-    const tokenRes = await axios.get(url)
-
-    //console.log(`tokenRes.data: ${util.inspect(tokenRes.data)}`)
-    //console.log(`tokenRes.data: ${JSON.stringify(tokenRes.data,null,2)}`)
-
-    let formattedTokens: Array<any> = []
-
-    if (tokenRes.data.u.length) {
-      tokenRes.data.u.forEach((token: any) => {
-        let div = "1"
-        for (let i = 0; i < parseInt(token.out[0].h8); i++) {
-          div += "0"
-        }
-
-        formattedTokens.push({
-          id: token.tx.h,
-          timestamp: token.blk
-            ? strftime("%Y-%m-%d %H:%M", new Date(token.blk.t * 1000))
-            : "unconfirmed",
-          symbol: token.out[0].s4,
-          name: token.out[0].s5,
-          documentUri: token.out[0].s6,
-          documentHash: token.out[0].h7,
-          decimals: parseInt(token.out[0].h8),
-          initialTokenQty: parseInt(token.out[0].h10, 16) / parseInt(div)
-        })
-      })
-    }
-
-    if (tokenRes.data.c.length) {
-      tokenRes.data.c.forEach((token: any) => {
-        let div = "1"
-        for (let i = 0; i < parseInt(token.out[0].h8); i++) {
-          div += "0"
-        }
-
-        formattedTokens.push({
-          id: token.tx.h,
-          timestamp: strftime("%Y-%m-%d %H:%M", new Date(token.blk.t * 1000)),
-          symbol: token.out[0].s4,
-          name: token.out[0].s5,
-          documentUri: token.out[0].s6,
-          documentHash: token.out[0].h7,
-          decimals: parseInt(token.out[0].h8),
-          initialTokenQty: parseInt(token.out[0].h10, 16) / parseInt(div)
-        })
-      })
-    }
-
-    //console.log(`formattedTokens: ${JSON.stringify(formattedTokens,null,2)}`)
-
-    let t
-    formattedTokens.forEach((token: any) => {
-      if (token.id === req.params.tokenId) t = token
-    })
-
-    // If token could not be found.
-    if (t === undefined) {
-      t = {
-        id: "not found"
-      }
-    }
-*/
     res.status(200)
     return res.json(t)
   } catch (err) {
@@ -359,7 +284,7 @@ async function listBulkToken(
       // Validate each element.
       if (!tokenId || tokenId === "") {
         res.status(400)
-        return res.json({ error: "Empty tokenId encountered" })
+        return res.json({ error: `Empty tokenId encountered in entry ${i}` })
       }
 
       const thisToken = await lookupToken(tokenId)
@@ -460,7 +385,7 @@ async function lookupToken(tokenId) {
 
     return t
   } catch(err) {
-    console.log(`Error in slp.ts/lookupToken()`)
+    //console.log(`Error in slp.ts/lookupToken()`)
     throw err
   }
 }

--- a/swaggerJSONFiles/components.json
+++ b/swaggerJSONFiles/components.json
@@ -116,6 +116,18 @@
           }
         }
       },
+      "SLPListBulk": {
+        "type": "object",
+        "properties": {
+          "tokenIds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SLPListBulk"
+            },
+            "example": []
+          }
+        }
+      },
       "SLPConvert": {
         "type": "object",
         "properties": {

--- a/swaggerJSONFiles/fixtures/mainnet/components.json
+++ b/swaggerJSONFiles/fixtures/mainnet/components.json
@@ -39,6 +39,13 @@
     ]
   },
   {
+    "key": "SLPListBulk",
+    "value": [
+      "650dea14c77f4d749608e36e375450c9ac91deb8b1b53e50cb0de2059a52d19a",
+      "c35a87afad11c8d086c1449ffd8b0a84324e72b15b1bcfdf166a493551b4eea6"
+    ]
+  },
+  {
     "key": "SLPTxids",
     "value": [
       "88b121101d71b73599dfc7d79eead599031912b2c48298bf5c1f37f4dd743ffa",

--- a/swaggerJSONFiles/fixtures/testnet/components.json
+++ b/swaggerJSONFiles/fixtures/testnet/components.json
@@ -39,6 +39,13 @@
     ]
   },
   {
+    "key": "SLPListBulk",
+    "value": [
+      "",
+      ""
+    ]
+  },
+  {
     "key": "SLPTxids",
     "value": [
       "3ea2767c91d087d14dda8faef736cd39d6c6ebbd5f7d2c7e8de0df3360436bfb",

--- a/swaggerJSONFiles/paths.json
+++ b/swaggerJSONFiles/paths.json
@@ -1497,6 +1497,30 @@
         }
       }
     },
+    "/slp/list": {
+      "post": {
+        "tags": ["slp"],
+        "summary": "list token information",
+        "description": "List multiple SLP tokens by id",
+        "operationId": "listBulk",
+        "requestBody": {
+          "description": "",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SLPListBulk" 
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful response"
+          }
+        }
+      }
+    },
     "/slp/convert/{address}": {
       "get": {
         "tags": ["slp"],

--- a/swaggerJSONFilesBuilt/mainnet/components.json
+++ b/swaggerJSONFilesBuilt/mainnet/components.json
@@ -137,6 +137,18 @@
 					}
 				}
 			},
+			"SLPListBulk": {
+				"type": "object",
+				"properties": {
+					"tokenIds": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/SLPListBulk"
+						},
+						"example": []
+					}
+				}
+			},
 			"SLPTxids": {
 				"type": "object",
 				"properties": {

--- a/swaggerJSONFilesBuilt/mainnet/paths.json
+++ b/swaggerJSONFilesBuilt/mainnet/paths.json
@@ -1548,13 +1548,24 @@
 			}
 		},
 		"/slp/list": {
-			"get": {
+			"post": {
 				"tags": [
 					"slp"
 				],
-				"summary": "list",
-				"description": "List all SLP tokens",
-				"operationId": "listAll",
+				"summary": "list token information",
+				"description": "List multiple SLP tokens by id",
+				"operationId": "listBulk",
+				"requestBody": {
+					"description": "",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/SLPListBulk"
+							}
+						}
+					}
+				},
 				"responses": {
 					"200": {
 						"description": "successful response"

--- a/swaggerJSONFilesBuilt/testnet/components.json
+++ b/swaggerJSONFilesBuilt/testnet/components.json
@@ -137,6 +137,18 @@
 					}
 				}
 			},
+			"SLPListBulk": {
+				"type": "object",
+				"properties": {
+					"tokenIds": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/SLPListBulk"
+						},
+						"example": []
+					}
+				}
+			},
 			"SLPTxids": {
 				"type": "object",
 				"properties": {

--- a/swaggerJSONFilesBuilt/testnet/paths.json
+++ b/swaggerJSONFilesBuilt/testnet/paths.json
@@ -1548,13 +1548,24 @@
 			}
 		},
 		"/slp/list": {
-			"get": {
+			"post": {
 				"tags": [
 					"slp"
 				],
-				"summary": "list",
-				"description": "List all SLP tokens",
-				"operationId": "listAll",
+				"summary": "list token information",
+				"description": "List multiple SLP tokens by id",
+				"operationId": "listBulk",
+				"requestBody": {
+					"description": "",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/SLPListBulk"
+							}
+						}
+					}
+				},
 				"responses": {
 					"200": {
 						"description": "successful response"

--- a/test/v2/slp.js
+++ b/test/v2/slp.js
@@ -225,6 +225,149 @@ describe("#SLP", () => {
     })
   })
 
+  describe("listBulkToken()", () => {
+    const listBulkToken = slpRoute.testableComponents.listBulkToken
+
+    it("should throw 400 if tokenIds array is empty", async () => {
+      const result = await listBulkToken(req, res)
+      // console.log(`result: ${util.inspect(result)}`)
+
+      assert.hasAllKeys(result, ["error"])
+      assert.include(result.error, "tokenIds needs to be an array")
+      assert.equal(res.statusCode, 400)
+    })
+
+    it("should throw 400 error if array is too large", async () => {
+      const testArray = []
+      for (var i = 0; i < 25; i++) testArray.push("")
+
+      req.body.tokenIds = testArray
+
+      const result = await listBulkToken(req, res)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      assert.hasAllKeys(result, ["error"])
+      assert.include(result.error, "Array too large")
+    })
+
+    it("should throw 400 if tokenId is empty", async () => {
+      req.body.tokenIds = [""]
+
+      const result = await listBulkToken(req, res)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      assert.hasAllKeys(result, ["error"])
+      assert.include(result.error, "Empty tokenId encountered")
+    })
+
+    it("should throw 503 when network issues", async () => {
+      // Save the existing BITDB_URL.
+      const savedUrl2 = process.env.BITDB_URL
+
+      // Manipulate the URL to cause a 500 network error.
+      process.env.BITDB_URL = "http://fakeurl/api/"
+
+      req.body.tokenIds = [
+        "650dea14c77f4d749608e36e375450c9ac91deb8b1b53e50cb0de2059a52d19a"
+      ]
+
+      const result = await listBulkToken(req, res)
+      // console.log(`result: ${util.inspect(result)}`)
+
+      // Restore the saved URL.
+      process.env.BITDB_URL = savedUrl2
+
+      assert.isAbove(
+        res.statusCode,
+        499,
+        "HTTP status code 500 or greater expected."
+      )
+      //assert.include(result.error,"Network error: Could not communicate with full node","Error message expected")
+    })
+
+    it("should return 'not found' for mainnet txid on testnet", async () => {
+      // Mock the RPC call for unit tests.
+      if (process.env.TEST === "unit") {
+        nock(mockServerUrl)
+          .get(uri => uri.includes("/"))
+          .reply(200, mockData.mockSingleToken)
+      }
+
+      req.body.tokenIds =
+        // testnet
+        //"650dea14c77f4d749608e36e375450c9ac91deb8b1b53e50cb0de2059a52d19a"
+        // mainnet
+        ["259908ae44f46ef585edef4bcc1e50dc06e4c391ac4be929fae27235b8158cf1"]
+
+      const result = await listBulkToken(req, res)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      assert.isArray(result)
+      assert.hasAllKeys(result[0], ["id"])
+      assert.include(result[0].id, "not found")
+    })
+
+    it("should get token information for single token ID", async () => {
+      // Mock the RPC call for unit tests.
+      if (process.env.TEST === "unit") {
+        nock(mockServerUrl)
+          .get(uri => uri.includes("/"))
+          .reply(200, mockData.mockSingleToken)
+      }
+
+      req.body.tokenIds =
+        // testnet
+        ["650dea14c77f4d749608e36e375450c9ac91deb8b1b53e50cb0de2059a52d19a"]
+
+      const result = await listBulkToken(req, res)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      assert.isArray(result)
+      assert.hasAllKeys(result[0], [
+        "id",
+        "timestamp",
+        "symbol",
+        "name",
+        "documentUri",
+        "documentHash",
+        "decimals",
+        "initialTokenQty"
+      ])
+    })
+
+    it("should get token information for multiple token IDs", async () => {
+      // Mock the RPC call for unit tests.
+      if (process.env.TEST === "unit") {
+        nock(mockServerUrl)
+          .get(uri => uri.includes("/"))
+          .times(2)
+          .reply(200, mockData.mockSingleToken)
+      }
+
+      req.body.tokenIds =
+        // testnet
+        [
+          "650dea14c77f4d749608e36e375450c9ac91deb8b1b53e50cb0de2059a52d19a",
+          "c35a87afad11c8d086c1449ffd8b0a84324e72b15b1bcfdf166a493551b4eea6"
+        ]
+
+      const result = await listBulkToken(req, res)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      assert.isArray(result)
+      assert.hasAllKeys(result[0], [
+        "id",
+        "timestamp",
+        "symbol",
+        "name",
+        "documentUri",
+        "documentHash",
+        "decimals",
+        "initialTokenQty"
+      ])
+    })
+  })
+
   describe("balancesForAddress()", () => {
     const balancesForAddress = slpRoute.testableComponents.balancesForAddress
 
@@ -387,7 +530,7 @@ describe("#SLP", () => {
     })
   })
 
-  describe("convertAddressSingle()", () => {
+  describe("convertAddressBulk()", () => {
     const convertAddressBulk = slpRoute.testableComponents.convertAddressBulk
 
     it("should throw 400 if addresses array is empty", async () => {


### PR DESCRIPTION
This PR fulfills PR #266. It includes these features:
- Adds a POST endpoint for `slp/list` where the `tokenIds` can be passed as an array
- Added unit and integration tests for this new endpoint
- Updates the Swagger UI.

Adding the POST entry for `slp/list` seems to have removed the GET `slp/list` entry from the Swagger UI. This needs to be looked at.