### PR TITLE
Fix SLP unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6382,6 +6382,16 @@
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
       "optional": true
     },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "requires": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      }
+    },
     "fill-range": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
@@ -8805,6 +8815,12 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
+    },
     "is-path-inside": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
@@ -9965,6 +9981,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
+      "dev": true
+    },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
       "dev": true
     },
     "moment": {
@@ -17635,6 +17657,28 @@
       "requires": {
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.8.0"
+      }
+    },
+    "proxyquire": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.0.tgz",
+      "integrity": "sha512-kptdFArCfGRtQFv3Qwjr10lwbEV0TBJYvfqzhwucyfEXqVgmnAkyEw/S3FYzR5HI9i5QOq4rcqQjZ6AlknlCDQ==",
+      "dev": true,
+      "requires": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.0",
+        "resolve": "~1.8.1"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+          "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.5"
+          }
+        }
       }
     },
     "prr": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1862,9 +1862,10 @@
       "integrity": "sha1-nGZalfiLiwj8Bc/XMfVhhZ1yWCU="
     },
     "bignumber.js": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
+      "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ==",
+      "dev": true
     },
     "binary-extensions": {
       "version": "1.13.0",
@@ -19118,6 +19119,13 @@
         "bchaddrjs-slp": "git://github.com/simpleledger/bchaddrjs.git#master",
         "bignumber.js": "^7.2.1",
         "bitcore-lib-cash": "^0.19.0"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+          "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+        }
       }
     },
     "snapdragon": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "devDependencies": {
     "@types/express": "^4.16.0",
     "@types/node": "^10.12.1",
+    "bignumber.js": "^8.1.1",
     "chai": "^4.1.2",
     "coveralls": "^3.0.2",
     "eslint": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "nyc": "^11.6.0",
     "pandacash-core": "^0.1.0",
     "prettier": "^1.14.2",
+    "proxyquire": "^2.1.0",
     "request": "^2.88.0",
     "request-promise": "^4.2.2",
     "semantic-release": "^15.11.0",

--- a/src/routes/v2/slp.ts
+++ b/src/routes/v2/slp.ts
@@ -469,6 +469,7 @@ async function balancesForAddress(
 
     // Get balances and utxos for the address of interest.
     const balances = await tmpbitboxNetwork.getAllSlpBalancesAndUtxos(slpAddr)
+    console.log(`balances: ${util.inspect(balances)}`)
 
     // If balances for this address exist, continue processing.
     if (balances.slpTokenBalances) {

--- a/src/routes/v2/slp.ts
+++ b/src/routes/v2/slp.ts
@@ -150,7 +150,6 @@ const slpValidator = createValidator(
 
 // Instantiate the bitboxproxy class in SLPJS.
 const bitboxproxy = new slp.BitboxNetwork(BITBOX, slpValidator)
-//console.log(`bitboxproxy: ${util.inspect(bitboxproxy)}`)
 
 const requestConfig: IRequestConfig = {
   method: "post",

--- a/src/routes/v2/slp.ts
+++ b/src/routes/v2/slp.ts
@@ -469,7 +469,6 @@ async function balancesForAddress(
 
     // Get balances and utxos for the address of interest.
     const balances = await tmpbitboxNetwork.getAllSlpBalancesAndUtxos(slpAddr)
-    //console.log(`balances: ${util.inspect(balances)}`)
 
     // If balances for this address exist, continue processing.
     if (balances.slpTokenBalances) {
@@ -480,7 +479,7 @@ async function balancesForAddress(
       // Query the token information for each token class found.
       const axiosPromises = keys.map(async (key: any) => {
         let tokenMetadata: any = await tmpbitboxNetwork.getTokenInformation(key)
-        console.log(`tokenMetadata: ${util.inspect(tokenMetadata,null,2)}`)
+
         return {
           tokenId: key,
           balance: balances.slpTokenBalances[key]

--- a/src/routes/v2/slp.ts
+++ b/src/routes/v2/slp.ts
@@ -469,7 +469,7 @@ async function balancesForAddress(
 
     // Get balances and utxos for the address of interest.
     const balances = await tmpbitboxNetwork.getAllSlpBalancesAndUtxos(slpAddr)
-    console.log(`balances: ${util.inspect(balances)}`)
+    //console.log(`balances: ${util.inspect(balances)}`)
 
     // If balances for this address exist, continue processing.
     if (balances.slpTokenBalances) {
@@ -480,6 +480,7 @@ async function balancesForAddress(
       // Query the token information for each token class found.
       const axiosPromises = keys.map(async (key: any) => {
         let tokenMetadata: any = await tmpbitboxNetwork.getTokenInformation(key)
+        console.log(`tokenMetadata: ${util.inspect(tokenMetadata,null,2)}`)
         return {
           tokenId: key,
           balance: balances.slpTokenBalances[key]

--- a/test/v2/mocks/slpjs-mocks.js
+++ b/test/v2/mocks/slpjs-mocks.js
@@ -5,9 +5,32 @@
 "use strict"
 
 const sinon = require("sinon")
+const proxyquire = require("proxyquire")
 
 class BitboxNetwork {
   constructor() {}
+
+  async getAllSlpBalancesAndUtxos(address) {
+    return {
+      satoshis_available_bch: 9996891,
+      satoshis_in_slp_baton: 546,
+      satoshis_in_slp_token: 546,
+      satoshis_in_invalid_token_dag: 0,
+      satoshis_in_invalid_baton_dag: 0,
+      slpTokenBalances: {
+        "7ac7f4bb50b019fe0f5c81e3fc13fc0720e130282ea460768cafb49785eb2796": []
+      },
+      slpTokenUtxos: {
+        "7ac7f4bb50b019fe0f5c81e3fc13fc0720e130282ea460768cafb49785eb2796": []
+      },
+      slpBatonUtxos: {
+        "7ac7f4bb50b019fe0f5c81e3fc13fc0720e130282ea460768cafb49785eb2796": []
+      },
+      nonSlpUtxos: [{}],
+      invalidTokenUtxos: [],
+      invalidBatonUtxos: []
+    }
+  }
 }
 
 const slpjs = {
@@ -15,3 +38,5 @@ const slpjs = {
   slp: {},
   validator: {}
 }
+
+module.exports = slpjs

--- a/test/v2/mocks/slpjs-mocks.js
+++ b/test/v2/mocks/slpjs-mocks.js
@@ -6,7 +6,9 @@
 
 const sinon = require("sinon")
 const proxyquire = require("proxyquire")
+const BigNumber = require("bignumber.js")
 
+// Mock the BitboxNetwork class.
 class BitboxNetwork {
   constructor() {}
 
@@ -18,7 +20,9 @@ class BitboxNetwork {
       satoshis_in_invalid_token_dag: 0,
       satoshis_in_invalid_baton_dag: 0,
       slpTokenBalances: {
-        "7ac7f4bb50b019fe0f5c81e3fc13fc0720e130282ea460768cafb49785eb2796": []
+        "7ac7f4bb50b019fe0f5c81e3fc13fc0720e130282ea460768cafb49785eb2796": new BigNumber(
+          123400000000
+        )
       },
       slpTokenUtxos: {
         "7ac7f4bb50b019fe0f5c81e3fc13fc0720e130282ea460768cafb49785eb2796": []
@@ -31,8 +35,28 @@ class BitboxNetwork {
       invalidBatonUtxos: []
     }
   }
+
+  async getTokenInformation(txid) {
+    BigNumber.set({ DECIMAL_PLACES: 8, ROUNDING_MODE: 4 })
+
+    const obj = {
+      versionType: 1,
+      transactionType: 0,
+      symbol: "SLPSDK",
+      name: "SLP SDK example using BITBOX",
+      documentUri: "developer.bitcoin.com",
+      documentSha256: null,
+      decimals: 8,
+      batonVout: 2,
+      containsBaton: true,
+      genesisOrMintQuantity: new BigNumber(123400000000)
+    }
+
+    return obj
+  }
 }
 
+// Mock the slpjs library.
 const slpjs = {
   BitboxNetwork,
   slp: {},

--- a/test/v2/mocks/slpjs-mocks.js
+++ b/test/v2/mocks/slpjs-mocks.js
@@ -1,0 +1,17 @@
+/*
+  Mocks used for unit tests that interact with slpjs.
+*/
+
+"use strict"
+
+const sinon = require("sinon")
+
+class BitboxNetwork {
+  constructor() {}
+}
+
+const slpjs = {
+  BitboxNetwork,
+  slp: {},
+  validator: {}
+}

--- a/test/v2/slp.js
+++ b/test/v2/slp.js
@@ -15,15 +15,19 @@ const chai = require("chai")
 const assert = chai.assert
 const nock = require("nock") // HTTP mocking
 const sinon = require("sinon")
+const proxyquire = require("proxyquire")
 
 // Prepare the slpRoute for stubbing dependcies on slpjs.
-const slpRoute = require("../../dist/routes/v2/slp")
+//const slpRoute = require("../../dist/routes/v2/slp")
+const pathStub = {}
+const slpRoute = proxyquire("../../dist/routes/v2/slp", { slpjs: pathStub })
 
 let originalEnvVars // Used during transition from integration to unit tests.
 
 // Mocking data.
 const { mockReq, mockRes } = require("./mocks/express-mocks")
 const mockData = require("./mocks/slp-mocks")
+const slpjsMock = require("./mocks/slpjs-mocks")
 
 // Used for debugging.
 const util = require("util")
@@ -441,17 +445,19 @@ describe("#SLP", () => {
         "Error message expected"
       )
     })
-    /*
+
     it("should get token balance for an address", async () => {
+      if (process.env.TEST === "unit")
+        pathStub.BitboxNetwork = slpjsMock.BitboxNetwork
+
       req.params.address = "slptest:qz4qnxcxwvmacgye8wlakhz0835x0w3vtvxu67w0ac"
 
       const result = await balancesForAddress(req, res)
       //console.log(`result: ${util.inspect(result)}`)
 
-      assert.isArray(result)
-      assert.hasAllKeys(result[0], ["tokenId", "balance", "decimalCount"])
+      //assert.isArray(result)
+      //assert.hasAllKeys(result[0], ["tokenId", "balance", "decimalCount"])
     })
-*/
   })
 
   describe("balancesForAddressByTokenID()", () => {

--- a/test/v2/slp.js
+++ b/test/v2/slp.js
@@ -36,13 +36,21 @@ describe("#SLP", () => {
   before(() => {
     // Save existing environment variables.
     originalEnvVars = {
-      BITDB_URL: process.env.BITDB_URL
+      BITDB_URL: process.env.BITDB_URL,
+      BITCOINCOM_BASEURL: process.env.BITCOINCOM_BASEURL,
+      SLP_VALIDATE_URL: process.env.SLP_VALIDATE_URL,
+      SLP_VALIDATE_FAILOVER_URL: process.env.SLP_VALIDATE_FAILOVER_URL
     }
 
     // Set default environment variables for unit tests.
     if (!process.env.TEST) process.env.TEST = "unit"
+
+    // Block network connections for unit tests.
     if (process.env.TEST === "unit") {
       process.env.BITDB_URL = "http://fakeurl/"
+      process.env.BITCOINCOM_BASEURL = "http://fakeurl/"
+      process.env.SLP_VALIDATE_URL = "http://fakeurl/"
+      process.env.SLP_VALIDATE_FAILOVER_URL = "http://fakeurl/"
       mockServerUrl = `http://fakeurl`
     }
   })
@@ -75,6 +83,10 @@ describe("#SLP", () => {
   after(() => {
     // Restore any pre-existing environment variables.
     process.env.BITDB_URL = originalEnvVars.BITDB_URL
+    process.env.BITCOINCOM_BASEURL = originalEnvVars.BITCOINCOM_BASEURL
+    process.env.SLP_VALIDATE_URL = originalEnvVars.SLP_VALIDATE_URL
+    process.env.SLP_VALIDATE_FAILOVER_URL =
+      originalEnvVars.SLP_VALIDATE_FAILOVER_URL
   })
 
   describe("#root", async () => {
@@ -400,29 +412,44 @@ describe("#SLP", () => {
       assert.include(result.error, "Invalid")
     })
 
-    // I don't think balancesForAddress() works yet, as it comes from slp-sdk?
-    /*
     it("should throw 5XX error when network issues", async () => {
-      // Save the existing BITDB_URL.
-      const savedUrl2 = process.env.BITDB_URL
+      // Save the existing rest URL settings.
+      const saveUrl1 = process.env.REST_URL
+      const saveUrl2 = process.env.TREST_URL
 
-      // Manipulate the URL to cause a 500 network error.
-      process.env.BITDB_URL = "http://fakeurl/api/"
+      // manipulate the rest url used by slpjs
+      process.env.REST_URL = "https://fakeurl/"
+      process.env.TREST_URL = "https://fakeurl/"
 
       req.params.address = "slptest:qz35h5mfa8w2pqma2jq06lp7dnv5fxkp2shlcycvd5"
 
       const result = await balancesForAddress(req, res)
-      console.log(`result: ${util.inspect(result)}`)
+      //console.log(`result: ${util.inspect(result)}`)
 
-      // Restore the saved URL.
-      process.env.BITDB_URL = savedUrl2
+      // Restore the functionality of slpjs
+      process.env.REST_URL = saveUrl1
+      process.env.TREST_URL = saveUrl2
 
-      assert.isAbove(res.statusCode, 499, "HTTP status code 500 or greater expected.")
+      assert.isAbove(
+        res.statusCode,
+        499,
+        "HTTP status code 500 or greater expected."
+      )
       assert.include(
         result.error,
         "Network error: Could not communicate",
         "Error message expected"
       )
+    })
+    /*
+    it("should get token balance for an address", async () => {
+      req.params.address = "slptest:qz4qnxcxwvmacgye8wlakhz0835x0w3vtvxu67w0ac"
+
+      const result = await balancesForAddress(req, res)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      assert.isArray(result)
+      assert.hasAllKeys(result[0], ["tokenId", "balance", "decimalCount"])
     })
 */
   })

--- a/test/v2/slp.js
+++ b/test/v2/slp.js
@@ -455,8 +455,8 @@ describe("#SLP", () => {
       const result = await balancesForAddress(req, res)
       //console.log(`result: ${util.inspect(result)}`)
 
-      //assert.isArray(result)
-      //assert.hasAllKeys(result[0], ["tokenId", "balance", "decimalCount"])
+      assert.isArray(result)
+      assert.hasAllKeys(result[0], ["tokenId", "balance", "decimalCount"])
     })
   })
 


### PR DESCRIPTION
This PR finishes building out the missing unit tests for the existing SLP endpoints. The trick was mocking the slpjs library using a new mocking library called proxyquire.