### PR TITLE
Multiple pro-tier password

### DIFF
--- a/dist/middleware/auth.js
+++ b/dist/middleware/auth.js
@@ -18,7 +18,9 @@ var util = require("util");
 util.inspect.defaultOptions = { depth: 1 };
 var _this;
 // Set default rate limit value for testing
-var PRO_PASS = process.env.PRO_PASS ? process.env.PRO_PASS : "BITBOX";
+var PRO_PASSes = process.env.PRO_PASS ? process.env.PRO_PASS : "BITBOX";
+// Convert the pro-tier password string into an array split by ':'.
+var PRO_PASS = PRO_PASSes.split(":");
 //wlogger.verbose(`PRO_PASS set to: ${PRO_PASS}`)
 // Auth Middleware
 var AuthMW = /** @class */ (function () {
@@ -46,14 +48,20 @@ var AuthMW = /** @class */ (function () {
             // Create the req.locals property if it does not yet exist.
             if (!req.locals)
                 req.locals = {};
-            //wlogger.verbose(`Auth passed with password ${password}`)
+            // Set pro-tier rate limit to flag to false by default.
+            req.locals.proLimit = false;
             // Evaluate the username and password and set the rate limit accordingly.
-            if (username === "BITBOX" && password === PRO_PASS) {
-                // Success
-                req.locals.proLimit = true;
-            }
-            else {
-                req.locals.proLimit = false;
+            //if (username === "BITBOX" && password === PRO_PASS) {
+            if (username === "BITBOX") {
+                for (var i = 0; i < PRO_PASS.length; i++) {
+                    var thisPass = PRO_PASS[i];
+                    if (password === thisPass) {
+                        wlogger.verbose(req.url + " called by " + password.slice(0, 6));
+                        // Success
+                        req.locals.proLimit = true;
+                        break;
+                    }
+                }
             }
             //console.log(`req.locals: ${util.inspect(req.locals)}`)
             return done(null, true);

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -23,7 +23,9 @@ util.inspect.defaultOptions = { depth: 1 }
 let _this
 
 // Set default rate limit value for testing
-const PRO_PASS = process.env.PRO_PASS ? process.env.PRO_PASS : "BITBOX"
+const PRO_PASSes = process.env.PRO_PASS ? process.env.PRO_PASS : "BITBOX"
+// Convert the pro-tier password string into an array split by ':'.
+const PRO_PASS = PRO_PASSes.split(":")
 
 //wlogger.verbose(`PRO_PASS set to: ${PRO_PASS}`)
 
@@ -62,14 +64,23 @@ class AuthMW {
         // Create the req.locals property if it does not yet exist.
         if (!req.locals) req.locals = {}
 
-        //wlogger.verbose(`Auth passed with password ${password}`)
+        // Set pro-tier rate limit to flag to false by default.
+        req.locals.proLimit = false
 
         // Evaluate the username and password and set the rate limit accordingly.
-        if (username === "BITBOX" && password === PRO_PASS) {
-          // Success
-          req.locals.proLimit = true
-        } else {
-          req.locals.proLimit = false
+        //if (username === "BITBOX" && password === PRO_PASS) {
+        if (username === "BITBOX") {
+          for (let i = 0; i < PRO_PASS.length; i++) {
+            const thisPass = PRO_PASS[i]
+
+            if (password === thisPass) {
+              wlogger.verbose(`Pro-tier activated by ${password.slice(0, 6)}`)
+
+              // Success
+              req.locals.proLimit = true
+              break
+            }
+          }
         }
 
         //console.log(`req.locals: ${util.inspect(req.locals)}`)

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -74,7 +74,7 @@ class AuthMW {
             const thisPass = PRO_PASS[i]
 
             if (password === thisPass) {
-              wlogger.verbose(`Pro-tier activated by ${password.slice(0, 6)}`)
+              wlogger.verbose(`${req.url} called by ${password.slice(0, 6)}`)
 
               // Success
               req.locals.proLimit = true


### PR DESCRIPTION
This PR enables multiple pro-tier passwords. Passwords are set by the environment variable `PRO_PASS`. Passwords are separated by a colon. Example:

`PRO_PASS=pass1:pass2:pass3`