### PR TITLE
Tweek to Error Logs

### DIFF
--- a/src/routes/v2/address.ts
+++ b/src/routes/v2/address.ts
@@ -90,8 +90,8 @@ async function detailsFromInsight(
 
     return retData
   } catch (err) {
-    logger.debug(`Error in detailsFromInsight().`)
-    wlogger.error(`Error in address.ts/detailsFromInsight().`, err)
+    // Dev Note: Do not log error messages here. Throw them instead and let the
+    // parent function handle it.
     throw err
   }
 }
@@ -289,8 +289,8 @@ async function utxoFromInsight(thisAddress: string) {
 
     return retData
   } catch (err) {
-    logger.debug(`Error in address.js/utxoFromInsight()`)
-    wlogger.error(`Error in address.ts/utxoFromInsight().`, err)
+    // Dev Note: Do not log error messages here. Throw them instead and let the
+    // parent function handle it.
     throw err
   }
 }
@@ -643,7 +643,8 @@ async function transactionsFromInsight(
 
     return retData
   } catch (err) {
-    wlogger.error(`Error in address.ts/transactionsFromInsight().`, err)
+    // Dev Note: Do not log error messages here. Throw them instead and let the
+    // parent function handle it.
     throw err
   }
 }

--- a/src/routes/v2/block.ts
+++ b/src/routes/v2/block.ts
@@ -51,14 +51,14 @@ async function detailsByHashSingle(
     const parsed = response.data
     return res.json(parsed)
   } catch (error) {
-    // Write out error to error log.
-    //logger.error(`Error in block/detailsByHash: `, error)
-    wlogger.error(`Error in block.ts/detailsByHashSingle().`, error)
-
     if (error.response && error.response.status === 404) {
       res.status(404)
       return res.json({ error: "Not Found" })
     }
+
+    // Write out error to error log.
+    //logger.error(`Error in block/detailsByHash: `, error)
+    wlogger.error(`Error in block.ts/detailsByHashSingle().`, error)
 
     res.status(500)
     return res.json({ error: util.inspect(error) })
@@ -242,14 +242,14 @@ async function detailsByHeightBulk(
     res.status(200)
     return res.json(result)
   } catch (error) {
-    // Write out error to error log.
-    //logger.error(`Error in block/detailsByHash: `, error)
-    wlogger.error(`Error in block.ts/detailsByHeightBulk().`, error)
-
     if (error.response && error.response.status === 404) {
       res.status(404)
       return res.json({ error: "Not Found" })
     }
+
+    // Write out error to error log.
+    //logger.error(`Error in block/detailsByHash: `, error)
+    wlogger.error(`Error in block.ts/detailsByHeightBulk().`, error)
 
     res.status(500)
     return res.json({ error: util.inspect(error) })

--- a/src/routes/v2/route-utils.js
+++ b/src/routes/v2/route-utils.js
@@ -5,6 +5,7 @@
 "use strict"
 
 const axios = require("axios")
+const wlogger = require("../../util/winston-logging")
 
 const util = require("util")
 util.inspect.defaultOptions = { depth: 1 }
@@ -108,6 +109,10 @@ function decodeError(err) {
     )
       return { msg: err.response.data.error.message, status: 400 }
 
+    // Attempt to extract the Insight error message
+    if (err.response && err.response.data)
+      return { msg: err.response.data, status: err.response.status }
+
     // Attempt to detect a network connection error.
     if (err.message && err.message.indexOf("ENOTFOUND") > -1) {
       return {
@@ -128,6 +133,7 @@ function decodeError(err) {
 
     return { msg: false, status: 500 }
   } catch (err) {
+    wlogger.error(`unhandled error in route-utils.js/decodeError(): `, err)
     return { msg: false, status: 500 }
   }
 }

--- a/src/routes/v2/transaction.ts
+++ b/src/routes/v2/transaction.ts
@@ -61,7 +61,8 @@ async function transactionsFromInsight(txid: string) {
 
     return parsed
   } catch (err) {
-    wlogger.error(`Error in transactions.ts/transactionsFromInsight().`, err)
+    // Dev Note: Do not log error messages here. Throw them instead and let the
+    // parent function handle it.
     throw err
   }
 }

--- a/test/v2/transaction.js
+++ b/test/v2/transaction.js
@@ -141,7 +141,7 @@ describe("#Transactions", () => {
       const result = await detailsBulk(req, res)
       //console.log(`result: ${util.inspect(result)}`)
 
-      assert.equal(res.statusCode, 500, "HTTP status code 500 expected.")
+      assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
     })
 
     it("should process a single txid", async () => {
@@ -259,7 +259,7 @@ describe("#Transactions", () => {
 
         // The error handling code should probably be updated to respond with a better
         // error message.
-        assert.equal(res.statusCode, 500, "HTTP status code 500 expected.")
+        assert.equal(res.statusCode, 400, "HTTP status code 400 expected.")
         assert.include(
           result.error,
           "parameter 1 must be hexadecimal string",


### PR DESCRIPTION
Endpoints like `transactions/detailsBulk()` were inappropriately handling errors and causing a lot of noise in the error logs. This PR makes a slight tweek to the error handling for these calls. It reduces noise in the error logs. Unit tests were updated to reflect these changes.