### PR TITLE
Fix 404 Error Handling

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -120,15 +120,15 @@ app.use(function (req, res, next) {
     next(err);
 });
 // error handler
-app.use(function (err, req, res) {
+app.use(function (err, req, res, next) {
     var status = err.status || 500;
     // set locals, only providing error in development
     res.locals.message = err.message;
     res.locals.error = req.app.get("env") === "development" ? err : {};
     // render the error page
-    res.status(err.status || 500);
+    res.status(status);
     res.json({
-        status: 500,
+        status: status,
         message: err.message
     });
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -168,16 +168,17 @@ app.use(
 )
 
 // error handler
-app.use((err: IError, req: express.Request, res: express.Response) => {
+app.use((err: IError, req: express.Request, res: express.Response, next: express.NextFunction) => {
   const status = err.status || 500
+
   // set locals, only providing error in development
   res.locals.message = err.message
   res.locals.error = req.app.get("env") === "development" ? err : {}
 
   // render the error page
-  res.status(err.status || 500)
+  res.status(status)
   res.json({
-    status: 500,
+    status: status,
     message: err.message
   })
 })


### PR DESCRIPTION
404 error handling was returning `[Object object]` on the command line. This PR fixes the error handling to return appropriate data to the user and on the command line.