### PR TITLE
Removing logging when pro-tier token is used

### DIFF
--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -74,7 +74,8 @@ class AuthMW {
             const thisPass = PRO_PASS[i]
 
             if (password === thisPass) {
-              wlogger.verbose(`${req.url} called by ${password.slice(0, 6)}`)
+              // Log when someone uses a pro-tier token
+              //wlogger.verbose(`${req.url} called by ${password.slice(0, 6)}`)
 
               // Success
               req.locals.proLimit = true


### PR DESCRIPTION
Whenever someone uses a pro-tier hard-coded token for an API call to unlock pro-tier rate limits, it gets logged to the local logging. This was done so that we could see when people started to use pro-tier tokens. Now that people are using them, it's clogging up the logs and preventing us from seeing legit errors.

This PR removes the logging of pro-tier API calls, so that the logs are easier to read.