### PR TITLE
Refining local logging code after tests

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -99,6 +99,7 @@ app.use(bodyParser.urlencoded({ extended: false }))
 app.use(cookieParser())
 app.use(express.static(path.join(__dirname, "public")))
 
+// Local logging middleware for tracking incoming connection information.
 app.use(`/`, logReqInfo)
 
 //

--- a/src/middleware/req-logging.ts
+++ b/src/middleware/req-logging.ts
@@ -1,5 +1,7 @@
 /*
-
+  This middleware logs connection information to local logs. It gives the ability
+  to detect when the server is being DDOS attacked, and also to collect metrics,
+  like the most popular endpoints.
 */
 
 import * as express from "express"
@@ -49,7 +51,7 @@ const logReqInfo = function(
     body: req.body
   }
 
-  wlogger.info(`Request: ${ip} ${method} ${url}`, dataToLog)
+  wlogger.verbose(`Request: ${ip} ${method} ${url}`, dataToLog)
 
   next()
 }

--- a/src/util/winston-logging.js
+++ b/src/util/winston-logging.js
@@ -18,8 +18,8 @@ var transport = new winston.transports.DailyRotateFile({
   filename: `${__dirname}/../../logs/rest-${NETWORK}-%DATE%.log`,
   datePattern: "YYYY-MM-DD",
   zippedArchive: false,
-  maxSize: "1m",
-  maxFiles: "20",
+  maxSize: "1m",   // 1 megabyte per file.
+  maxFiles: "100", // Will overwrite old log files after 100 megs used.
   format: winston.format.combine(
     winston.format.timestamp(),
     winston.format.json()


### PR DESCRIPTION
- Increases the local logging cache to 100 megabytes. I've run tests to ensure that old logs are overwritten by new logs, once the maximum size for log files is reached.

- Switches the logging level to 'verbose', which is in-between 'debug' and 'info'. Can turn off local logging of connection information by changing logging level to 'info'.