### PR TITLE
Incorporating wtfnode to monitor event loop in logs

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -1,5 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+var wtfnode = require("wtfnode"); // Debugging the event loop
+var util = require("util");
 var express = require("express");
 var req_logging_1 = require("./middleware/req-logging");
 // Middleware
@@ -194,6 +196,19 @@ server.on("listening", onListening);
 // Set the time before a timeout error is generated. This impacts testing and
 // the handling of timeout errors. Is 10 seconds too agressive?
 server.setTimeout(30 * 1000);
+// Dump details about the event loop to debug a possible memory leak
+wtfnode.setLogger("info", function (data) {
+    wlogger.verbose("wtfnode info: " + data);
+});
+wtfnode.setLogger("warn", function (data) {
+    wlogger.verbose("wtfnode warn: " + data);
+});
+wtfnode.setLogger("error", function (data) {
+    wlogger.verbose("wtfnode error: " + data);
+});
+setInterval(function () {
+    wtfnode.dump();
+}, 60000);
 /**
  * Normalize a port into a number, string, or false.
  */

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "request-promise": "^4.2.2",
     "semantic-release": "^15.11.0",
     "sinon": "^6.3.4",
-    "typescript": "^3.1.4"
+    "typescript": "^3.1.4",
+    "wtfnode": "^0.8.0"
   },
   "release": {
     "publish": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,8 @@
 "use strict"
+
+const wtfnode = require("wtfnode") // Debugging the event loop
+const util = require("util")
+
 import * as express from "express"
 import { logReqInfo } from "./middleware/req-logging"
 // Middleware
@@ -226,9 +230,7 @@ const io = require("socket.io").listen(server)
 
 if (process.env.ZEROMQ_URL && process.env.ZEROMQ_PORT) {
   console.log(
-    `Connecting to BCH ZMQ at ${process.env.ZEROMQ_URL}:${
-      process.env.ZEROMQ_PORT
-    }`
+    `Connecting to BCH ZMQ at ${process.env.ZEROMQ_URL}:${process.env.ZEROMQ_PORT}`
   )
   const bitcoincashZmqDecoder = new BitcoinCashZMQDecoder(process.env.NETWORK)
 
@@ -268,6 +270,20 @@ server.on("listening", onListening)
 // Set the time before a timeout error is generated. This impacts testing and
 // the handling of timeout errors. Is 10 seconds too agressive?
 server.setTimeout(30 * 1000)
+
+// Dump details about the event loop to debug a possible memory leak
+wtfnode.setLogger("info", function(data) {
+  wlogger.verbose(`wtfnode info: ${data}`)
+})
+wtfnode.setLogger("warn", function(data) {
+  wlogger.verbose(`wtfnode warn: ${data}`)
+})
+wtfnode.setLogger("error", function(data) {
+  wlogger.verbose(`wtfnode error: ${data}`)
+})
+setInterval(function() {
+  wtfnode.dump()
+}, 60000 * 5)
 
 /**
  * Normalize a port into a number, string, or false.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1902,7 +1902,6 @@ bitcoincashjs-lib@Bitcoin-com/bitcoincashjs-lib#v4.0.1:
 
 "bitcoincashjs-lib@https://github.com/Bitcoin-com/bitcoincashjs-lib.git":
   version "4.0.1"
-  uid "28447b40a4ccd23913f7ade6589dc7214c99e60a"
   resolved "https://github.com/Bitcoin-com/bitcoincashjs-lib.git#28447b40a4ccd23913f7ade6589dc7214c99e60a"
   dependencies:
     bech32 "^1.1.2"
@@ -10917,6 +10916,11 @@ ws@~6.1.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.4.tgz#5b5c8800afab925e94ccb29d153c8d02c1776ef9"
   dependencies:
     async-limiter "~1.0.0"
+
+wtfnode@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/wtfnode/-/wtfnode-0.8.0.tgz#26a1a6b8e07727d7ed29dacc6708bea4647ccd20"
+  integrity sha512-A5jm/0REykxUac1q4Q5kv+hDIiacvqVpwIoXzCQcRL7syeEKucVVOxyLLrt+jIiZoXfla3lnsxUw/cmWXIaGWA==
 
 x-xss-protection@1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Adds the [wtfnode](https://www.npmjs.com/package/wtfnode) package to the dev dependencies. It logs data about the node.js event loop every 5 minutes to the local logs. This will hopefully help us get a handle the increase in CPU usage over time.