### PR TITLE
Adding getNetworkInfo RPC call

### DIFF
--- a/src/routes/v2/control.ts
+++ b/src/routes/v2/control.ts
@@ -13,7 +13,7 @@ util.inspect.defaultOptions = { depth: 1 }
 
 router.get("/", root)
 router.get("/getInfo", getInfo)
-router.get("/getNetworkInfo", getNeworkInfo)
+router.get("/getNetworkInfo", getNetworkInfo)
 
 function root(
   req: express.Request,
@@ -56,7 +56,7 @@ async function getInfo(
 
 
 // Execute the RPC getinfo call.
-async function getNeworkInfo(
+async function getNetworkInfo(
   req: express.Request,
   res: express.Response,
   next: express.NextFunction
@@ -126,6 +126,7 @@ module.exports = {
   router,
   testableComponents: {
     root,
-    getInfo
+    getInfo,
+    getNetworkInfo
   }
 }

--- a/src/routes/v2/control.ts
+++ b/src/routes/v2/control.ts
@@ -13,6 +13,7 @@ util.inspect.defaultOptions = { depth: 1 }
 
 router.get("/", root)
 router.get("/getInfo", getInfo)
+router.get("/getNetworkInfo", getNeworkInfo)
 
 function root(
   req: express.Request,
@@ -23,6 +24,7 @@ function root(
 }
 
 // Execute the RPC getinfo call.
+// Deprecated in v0.19.08 of ABC full node.
 async function getInfo(
   req: express.Request,
   res: express.Response,
@@ -41,6 +43,37 @@ async function getInfo(
     return res.json(info)
   } catch (error) {
     wlogger.error(`Error in control.ts/getInfo().`, error)
+
+    // Write out error to error log.
+    //logger.error(`Error in control/getInfo: `, error)
+
+    res.status(500)
+    if (error.response && error.response.data && error.response.data.error)
+      return res.json({ error: error.response.data.error })
+    return res.json({ error: util.inspect(error) })
+  }
+}
+
+
+// Execute the RPC getinfo call.
+async function getNeworkInfo(
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+): Promise<express.Response> {
+  const { BitboxHTTP, requestConfig } = routeUtils.setEnvVars()
+
+  requestConfig.data.id = "getnetworkinfo"
+  requestConfig.data.method = "getnetworkinfo"
+  requestConfig.data.params = []
+
+  try {
+    const response: AxiosResponse = await BitboxHTTP(requestConfig)
+    const info: InfoInterface = response.data.result
+
+    return res.json(info)
+  } catch (error) {
+    wlogger.error(`Error in control.ts/getNetworkInfo().`, error)
 
     // Write out error to error log.
     //logger.error(`Error in control/getInfo: `, error)

--- a/test/v2/control.js
+++ b/test/v2/control.js
@@ -135,4 +135,57 @@ describe("#ControlRouter", () => {
       ])
     })
   })
+
+  describe("#GetNetworkInfo", () => {
+    const getNetworkInfo = controlRoute.testableComponents.getNetworkInfo
+
+    it("should throw 500 when network issues", async () => {
+      // Save the existing RPC URL.
+      const savedUrl = process.env.RPC_BASEURL
+
+      // Manipulate the URL to cause a 500 network error.
+      process.env.RPC_BASEURL = "http://fakeurl/api/"
+
+      const result = await getNetworkInfo(req, res)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      // Restore the saved URL.
+      process.env.RPC_BASEURL = savedUrl
+
+      assert.isAbove(
+        res.statusCode,
+        499,
+        "HTTP status code 500 or greater expected."
+      )
+      //assert.include(result.error, "ENOTFOUND", "Error message expected")
+    })
+
+    it("should get info on the full node", async () => {
+      // Mock the RPC call for unit tests.
+      if (process.env.TEST === "unit") {
+        nock(`${process.env.RPC_BASEURL}`)
+          .post(``)
+          .reply(200, { result: mockData.mockGetNetworkInfo })
+      }
+
+      const result = await getNetworkInfo(req, res)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      assert.hasAnyKeys(result, [
+        "version",
+        "subversion",
+        "protocolversion",
+        "localservices",
+        "localrelay",
+        "timeoffset",
+        "networkactive",
+        "connections",
+        "networks",
+        "relayfee",
+        "excessutxocharge",
+        "localaddresses",
+        "warnings"
+      ])
+    })
+  })
 })

--- a/test/v2/mocks/control-mock.js
+++ b/test/v2/mocks/control-mock.js
@@ -2,8 +2,6 @@
   This library contains mocking data for running unit tests on the address route.
 */
 
-"use strict"
-
 const mockGetInfo = {
   version: 170200,
   protocolversion: 70015,
@@ -22,6 +20,24 @@ const mockGetInfo = {
   errors: "Warning: unknown new rules activated (versionbit 28)"
 }
 
+mockGetNetworkInfo = {
+  version: 190600,
+  subversion: "/Bitcoin ABC:0.19.6(EB32.0)/",
+  protocolversion: 70015,
+  localservices: "0000000000000425",
+  localrelay: true,
+  timeoffset: 0,
+  networkactive: true,
+  connections: 18,
+  networks: [{}, {}, {}],
+  relayfee: 0.00001,
+  excessutxocharge: 0,
+  localaddresses: [],
+  warnings:
+    "Warning: Unknown block versions being mined! It's possible unknown rules are in effect"
+}
+
 module.exports = {
-  mockGetInfo
+  mockGetInfo,
+  mockGetNetworkInfo
 }


### PR DESCRIPTION
The `getInfo` JSON RPC call has been deprecated in the ABC v0.19.08 full node implementation. This PR adds the `getNeworkInfo` RPC call to the Control route. This is the only functional RPC call that will report the version of the currently running node.

This PR also includes unit and integration tests. Once this PR is merged into stage, I'll add an endpoint to BITBOX SDK to call it.