### PR TITLE
Basic Auth for private SLPDB

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var wtfnode = require("wtfnode"); // Debugging the event loop
+// const wtfnode = require("wtfnode") // Debugging the event loop
 // const util = require("util")
 var express = require("express");
 var req_logging_1 = require("./middleware/req-logging");
@@ -126,18 +126,18 @@ server.on("listening", onListening);
 // the handling of timeout errors. Is 10 seconds too agressive?
 server.setTimeout(30 * 1000);
 // Dump details about the event loop to debug a possible memory leak
-wtfnode.setLogger("info", function (data) {
-    wlogger.verbose("wtfnode info: " + data);
-});
-wtfnode.setLogger("warn", function (data) {
-    wlogger.verbose("wtfnode warn: " + data);
-});
-wtfnode.setLogger("error", function (data) {
-    wlogger.verbose("wtfnode error: " + data);
-});
-setInterval(function () {
-    wtfnode.dump();
-}, 60000 * 5);
+// wtfnode.setLogger("info", function(data) {
+//   wlogger.verbose(`wtfnode info: ${data}`)
+// })
+// wtfnode.setLogger("warn", function(data) {
+//   wlogger.verbose(`wtfnode warn: ${data}`)
+// })
+// wtfnode.setLogger("error", function(data) {
+//   wlogger.verbose(`wtfnode error: ${data}`)
+// })
+// setInterval(function() {
+//   wtfnode.dump()
+// }, 60000 * 5)
 /**
  * Normalize a port into a number, string, or false.
  */

--- a/dist/middleware/auth.js
+++ b/dist/middleware/auth.js
@@ -8,7 +8,6 @@
   If the header is found and validated, the req.locals.proLimit Boolean value
   is set and passed to the route-ratelimits.ts middleware.
 */
-"use strict";
 var passport = require("passport");
 var BasicStrategy = require("passport-http").BasicStrategy;
 var AnonymousStrategy = require("passport-anonymous");

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,6 @@
 "use strict"
 
-const wtfnode = require("wtfnode") // Debugging the event loop
+// const wtfnode = require("wtfnode") // Debugging the event loop
 // const util = require("util")
 
 import * as express from "express"
@@ -190,18 +190,18 @@ server.on("listening", onListening)
 server.setTimeout(30 * 1000)
 
 // Dump details about the event loop to debug a possible memory leak
-wtfnode.setLogger("info", function(data) {
-  wlogger.verbose(`wtfnode info: ${data}`)
-})
-wtfnode.setLogger("warn", function(data) {
-  wlogger.verbose(`wtfnode warn: ${data}`)
-})
-wtfnode.setLogger("error", function(data) {
-  wlogger.verbose(`wtfnode error: ${data}`)
-})
-setInterval(function() {
-  wtfnode.dump()
-}, 60000 * 5)
+// wtfnode.setLogger("info", function(data) {
+//   wlogger.verbose(`wtfnode info: ${data}`)
+// })
+// wtfnode.setLogger("warn", function(data) {
+//   wlogger.verbose(`wtfnode warn: ${data}`)
+// })
+// wtfnode.setLogger("error", function(data) {
+//   wlogger.verbose(`wtfnode error: ${data}`)
+// })
+// setInterval(function() {
+//   wtfnode.dump()
+// }, 60000 * 5)
 
 /**
  * Normalize a port into a number, string, or false.

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -9,8 +9,6 @@
   is set and passed to the route-ratelimits.ts middleware.
 */
 
-"use strict"
-
 const passport = require("passport")
 const BasicStrategy = require("passport-http").BasicStrategy
 const AnonymousStrategy = require("passport-anonymous")

--- a/src/routes/v2/slp.ts
+++ b/src/routes/v2/slp.ts
@@ -42,6 +42,10 @@ if (!process.env.REST_URL) process.env.REST_URL = `https://rest.bitcoin.com/v2/`
 if (!process.env.TREST_URL)
   process.env.TREST_URL = `https://trest.bitcoin.com/v2/`
 
+// Determine the Access password for a private instance of SLPDB.
+// https://gist.github.com/christroutner/fc717ca704dec3dded8b52fae387eab2
+const SLPDB_PASS = process.env.SLPDB_PASS ? process.env.SLPDB_PASS : "BITBOX"
+
 router.get("/", root)
 router.get("/list", list)
 router.get("/list/:tokenId", listSingleToken)
@@ -232,8 +236,10 @@ async function list(
     const b64: string = Buffer.from(s).toString("base64")
     const url: string = `${process.env.SLPDB_URL}q/${b64}`
 
+    const options = generateCredentials()
+
     // Get data from SLPDB.
-    const tokenRes: AxiosResponse = await axios.get(url)
+    const tokenRes: AxiosResponse = await axios.get(url, options)
 
     const formattedTokens: TokenInterface[] = []
 
@@ -305,7 +311,9 @@ async function listSingleToken(
     const b64: string = Buffer.from(s).toString("base64")
     const url: string = `${process.env.SLPDB_URL}q/${b64}`
 
-    const tokenRes: AxiosResponse = await axios.get(url)
+    const options = generateCredentials()
+
+    const tokenRes: AxiosResponse = await axios.get(url,options)
 
     let token
     res.status(200)
@@ -385,7 +393,9 @@ async function listBulkToken(
     const b64: string = Buffer.from(s).toString("base64")
     const url: string = `${process.env.SLPDB_URL}q/${b64}`
 
-    const tokenRes: AxiosResponse = await axios.get(url)
+    const options = generateCredentials()
+
+    const tokenRes: AxiosResponse = await axios.get(url,options)
 
     const formattedTokens: any[] = []
     const txids: string[] = []
@@ -454,7 +464,9 @@ async function lookupToken(tokenId: string): Promise<any> {
     const b64: string = Buffer.from(s).toString("base64")
     const url: string = `${process.env.SLPDB_URL}q/${b64}`
 
-    const tokenRes: AxiosResponse = await axios.get(url)
+    const options = generateCredentials()
+
+    const tokenRes: AxiosResponse = await axios.get(url, options)
 
     const formattedTokens: any[] = []
 
@@ -541,7 +553,9 @@ async function balancesForAddressSingle(
     const b64: string = Buffer.from(s).toString("base64")
     const url: string = `${process.env.SLPDB_URL}q/${b64}`
 
-    const tokenRes: AxiosResponse = await axios.get(url)
+    const options = generateCredentials()
+
+    const tokenRes: AxiosResponse = await axios.get(url, options)
 
     const tokenIds: string[] = []
     if (tokenRes.data.a.length > 0) {
@@ -709,7 +723,9 @@ async function balancesForAddressBulk(
           const b64: string = Buffer.from(s).toString("base64")
           const url: string = `${process.env.SLPDB_URL}q/${b64}`
 
-          const tokenRes: AxiosResponse<any> = await axios.get(url)
+          const options = generateCredentials()
+
+          const tokenRes: AxiosResponse<any> = await axios.get(url, options)
 
           const tokenIds: string[] = []
 
@@ -837,8 +853,10 @@ async function balancesForTokenSingle(
     const b64: string = Buffer.from(s).toString("base64")
     const url: string = `${process.env.SLPDB_URL}q/${b64}`
 
+    const options = generateCredentials()
+
     // Get data from SLPDB.
-    const tokenRes: AxiosResponse = await axios.get(url)
+    const tokenRes: AxiosResponse = await axios.get(url, options)
     const resBalances: BalancesForToken[] = tokenRes.data.a.map(
       (addy: any): any => {
         delete addy.satoshis_balance
@@ -931,8 +949,10 @@ async function balancesForTokenBulk(
           const b64: string = Buffer.from(s).toString("base64")
           const url: string = `${process.env.SLPDB_URL}q/${b64}`
 
+          const options = generateCredentials()
+
           // Get data from SLPDB.
-          const tokenRes: AxiosResponse = await axios.get(url)
+          const tokenRes: AxiosResponse = await axios.get(url, options)
 
           const resBalances = tokenRes.data.a.map((addy: any): any => {
             delete addy.satoshis_balance
@@ -1036,8 +1056,10 @@ async function balancesForAddressByTokenIDSingle(
     const b64: string = Buffer.from(s).toString("base64")
     const url: string = `${process.env.SLPDB_URL}q/${b64}`
 
+    const options = generateCredentials()
+
     // Get data from SLPDB.
-    const tokenRes: AxiosResponse<any> = await axios.get(url)
+    const tokenRes: AxiosResponse<any> = await axios.get(url, options)
     let resVal: BalanceForAddressByTokenId = {
       cashAddress: utils.toCashAddress(slpAddr),
       legacyAddress: utils.toLegacyAddress(slpAddr),
@@ -1155,8 +1177,10 @@ async function balancesForAddressByTokenIDBulk(
         const b64: string = Buffer.from(s).toString("base64")
         const url: string = `${process.env.SLPDB_URL}q/${b64}`
 
+        const options = generateCredentials()
+
         // Get data from SLPDB.
-        const tokenRes: AxiosResponse<any> = await axios.get(url)
+        const tokenRes: AxiosResponse<any> = await axios.get(url, options)
 
         let resVal: BalanceForAddressByTokenId = {
           cashAddress: utils.toCashAddress(slpAddr),
@@ -1349,8 +1373,10 @@ async function validateBulk(
     const b64 = Buffer.from(s).toString("base64")
     const url = `${process.env.SLPDB_URL}q/${b64}`
 
+    const options = generateCredentials()
+
     // Get data from SLPDB.
-    const tokenRes = await axios.get(url)
+    const tokenRes = await axios.get(url, options)
 
     const formattedTokens: any[] = []
 
@@ -1424,12 +1450,14 @@ async function validateSingle(
       }
     }
 
+    const options = generateCredentials()
+
     const s = JSON.stringify(query)
     const b64 = Buffer.from(s).toString("base64")
     const url = `${process.env.SLPDB_URL}q/${b64}`
 
     // Get data from SLPDB.
-    const tokenRes = await axios.get(url)
+    const tokenRes = await axios.get(url, options)
 
     let result: any = {
       txid: txid,
@@ -1508,8 +1536,10 @@ async function burnTotalSingle(
     const b64: string = Buffer.from(s).toString("base64")
     const url: string = `${process.env.SLPDB_URL}q/${b64}`
 
+    const options = generateCredentials()
+
     // Get data from SLPDB.
-    const tokenRes: AxiosResponse = await axios.get(url)
+    const tokenRes: AxiosResponse = await axios.get(url, options)
 
     const burnTotal: BurnTotalResult = {
       transactionId: txid,
@@ -1599,8 +1629,10 @@ async function burnTotalBulk(
       const b64: string = Buffer.from(s).toString("base64")
       const url: string = `${process.env.SLPDB_URL}q/${b64}`
 
+      const options = generateCredentials()
+
       // Get data from SLPDB.
-      const tokenRes = await axios.get(url)
+      const tokenRes = await axios.get(url, options)
       const burnTotal: BurnTotalResult = {
         transactionId: txids[0],
         inputTotal: 0,
@@ -1921,8 +1953,10 @@ async function txDetails(
     const b64 = Buffer.from(s).toString("base64")
     const url = `${process.env.SLPDB_URL}q/${b64}`
 
+    const options = generateCredentials()
+
     // Get token data from SLPDB
-    const tokenRes = await axios.get(url)
+    const tokenRes = await axios.get(url, options)
     // console.log(`tokenRes: ${util.inspect(tokenRes)}`)
 
     // Format the returned data to an object.
@@ -2143,7 +2177,9 @@ async function tokenStatsSingle(
     const b64: string = Buffer.from(s).toString("base64")
     const url: string = `${process.env.SLPDB_URL}q/${b64}`
 
-    const tokenRes: AxiosResponse<any> = await axios.get(url)
+    const options = generateCredentials()
+
+    const tokenRes: AxiosResponse<any> = await axios.get(url, options)
 
     const formattedTokens: any[] = []
 
@@ -2229,7 +2265,9 @@ async function tokenStatsBulk(
         const b64: string = Buffer.from(s).toString("base64")
         const url: string = `${process.env.SLPDB_URL}q/${b64}`
 
-        const tokenRes: AxiosResponse<any> = await axios.get(url)
+        const options = generateCredentials()
+
+        const tokenRes: AxiosResponse<any> = await axios.get(url, options)
 
         const formattedTokens: any[] = []
 
@@ -2310,8 +2348,10 @@ async function txsTokenIdAddressSingle(
     const b64: string = Buffer.from(s).toString("base64")
     const url: string = `${process.env.SLPDB_URL}q/${b64}`
 
+    const options = generateCredentials()
+
     // Get data from SLPDB.
-    const tokenRes: AxiosResponse = await axios.get(url)
+    const tokenRes: AxiosResponse = await axios.get(url, options)
 
     return res.json(tokenRes.data.c)
   } catch (err) {
@@ -2411,8 +2451,10 @@ async function txsTokenIdAddressBulk(
         const b64: string = Buffer.from(s).toString("base64")
         const url: string = `${process.env.SLPDB_URL}q/${b64}`
 
+        const options = generateCredentials()
+
         // Get data from SLPDB.
-        const tokenRes: AxiosResponse = await axios.get(url)
+        const tokenRes: AxiosResponse = await axios.get(url, options)
 
         return tokenRes.data.c
       } catch (err) {
@@ -2437,6 +2479,23 @@ async function txsTokenIdAddressBulk(
       error: `Error in /transactions/:tokenId/:address: ${err.message}`
     })
   }
+}
+
+function generateCredentials() {
+  // Generate the Basic Authentication header for a private instance of SLPDB.
+  const username = "BITBOX"
+  const password = SLPDB_PASS
+  const combined = `${username}:${password}`
+  var base64Credential = Buffer.from(combined).toString('base64')
+  var readyCredential = 'Basic '+base64Credential;
+
+  const options = {
+    headers: {
+      authorization: readyCredential
+    }
+  }
+
+  return options
 }
 
 module.exports = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1876,7 +1876,7 @@ bip-schnorr@^0.3.0:
     random-bytes "^1.0.0"
     safe-buffer "^5.0.1"
 
-bip21@Bitcoin-com/bip21, "bip21@github:Bitcoin-com/bip21":
+bip21@Bitcoin-com/bip21:
   version "2.0.1"
   resolved "https://codeload.github.com/Bitcoin-com/bip21/tar.gz/28f8d03a3a16ed11eb5b963248ed1be8c46c6d6f"
   dependencies:
@@ -1891,7 +1891,7 @@ bip32-utils@Bitcoin-com/bip32-utils#0.13.0:
     standard "^11.0.1"
     tape "*"
 
-bip32-utils@Bitcoin-com/bip32-utils#0.13.1, "bip32-utils@github:Bitcoin-com/bip32-utils#0.13.1":
+bip32-utils@Bitcoin-com/bip32-utils#0.13.1:
   version "0.13.1"
   resolved "https://codeload.github.com/Bitcoin-com/bip32-utils/tar.gz/b8a33ebd0a0ac39de7cd987e5c3f77a8c5d84e58"
   dependencies:
@@ -2081,7 +2081,7 @@ bitcoin-txdecoder@0.0.3:
   dependencies:
     bitcoinjs-lib "3.3.*"
 
-bitcoincash-ops@Bitcoin-com/bitcoincash-ops#2.0.0, "bitcoincash-ops@github:Bitcoin-com/bitcoincash-ops#2.0.0":
+bitcoincash-ops@Bitcoin-com/bitcoincash-ops#2.0.0:
   version "2.0.0"
   resolved "https://codeload.github.com/Bitcoin-com/bitcoincash-ops/tar.gz/6ab82cc7326c67236f3b2d9d0457258ac2ef48e3"
 
@@ -2112,9 +2112,9 @@ bitcoincashjs-lib@Bitcoin-com/bitcoincashjs-lib#3.3.4:
     varuint-bitcoin "^1.0.4"
     wif "^2.0.1"
 
-bitcoincashjs-lib@Bitcoin-com/bitcoincashjs-lib#v4.0.1:
-  version "4.0.1"
-  resolved "https://codeload.github.com/Bitcoin-com/bitcoincashjs-lib/tar.gz/28447b40a4ccd23913f7ade6589dc7214c99e60a"
+bitcoincashjs-lib@Bitcoin-com/bitcoincashjs-lib#v4.0.0:
+  version "4.0.0"
+  resolved "https://codeload.github.com/Bitcoin-com/bitcoincashjs-lib/tar.gz/3d360c780ec7df4a74aea93664c2b5ff8b08949a"
   dependencies:
     bech32 "^1.1.2"
     bigi "^1.4.0"
@@ -2132,9 +2132,9 @@ bitcoincashjs-lib@Bitcoin-com/bitcoincashjs-lib#v4.0.1:
     varuint-bitcoin "^1.0.4"
     wif "^2.0.1"
 
-"bitcoincashjs-lib@github:Bitcoin-com/bitcoincashjs-lib#v4.0.0":
-  version "4.0.0"
-  resolved "https://codeload.github.com/Bitcoin-com/bitcoincashjs-lib/tar.gz/3d360c780ec7df4a74aea93664c2b5ff8b08949a"
+bitcoincashjs-lib@Bitcoin-com/bitcoincashjs-lib#v4.0.1:
+  version "4.0.1"
+  resolved "https://codeload.github.com/Bitcoin-com/bitcoincashjs-lib/tar.gz/28447b40a4ccd23913f7ade6589dc7214c99e60a"
   dependencies:
     bech32 "^1.1.2"
     bigi "^1.4.0"
@@ -3231,7 +3231,7 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-coininfo@Bitcoin-com/coininfo, "coininfo@github:Bitcoin-com/coininfo":
+coininfo@Bitcoin-com/coininfo:
   version "4.0.0"
   resolved "https://codeload.github.com/Bitcoin-com/coininfo/tar.gz/eece2c6141d08c3e7783929f2a1e1e681aa1a82c"
   dependencies:


### PR DESCRIPTION
This PR adds a [Basic Authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) header to each call to SLPDB in the slp.ts route library. This enables rest to talk to its own private instance of SLPDB. See [this gist](https://gist.github.com/christroutner/fc717ca704dec3dded8b52fae387eab2) for additional details.

The authentication password is set by `SLPDB_PASS` environment variable, and defaults to `BITBOX`.