### PR TITLE
fix(txdetails): Improved error handling for txdetails

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -189,20 +189,6 @@ server.on("listening", onListening)
 // the handling of timeout errors. Is 10 seconds too agressive?
 server.setTimeout(30 * 1000)
 
-// Dump details about the event loop to debug a possible memory leak
-// wtfnode.setLogger("info", function(data) {
-//   wlogger.verbose(`wtfnode info: ${data}`)
-// })
-// wtfnode.setLogger("warn", function(data) {
-//   wlogger.verbose(`wtfnode warn: ${data}`)
-// })
-// wtfnode.setLogger("error", function(data) {
-//   wlogger.verbose(`wtfnode error: ${data}`)
-// })
-// setInterval(function() {
-//   wtfnode.dump()
-// }, 60000 * 5)
-
 /**
  * Normalize a port into a number, string, or false.
  */

--- a/test/v2/slp.js
+++ b/test/v2/slp.js
@@ -1117,6 +1117,16 @@ describe("#SLP", () => {
 
         assert.hasAnyKeys(result, ["tokenIsValid", "tokenInfo"])
       })
+
+      it("should throw an error for a non-existent txid", async () => {
+        req.params.txid =
+          "57b3082a2bf269b3d6f40fee7fb9c664e8256a88ca5ee2697c05b9457822d555"
+
+        const result = await txDetails(req, res)
+        // console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+        assert.equal(result.error, "SLP transaction not found")
+      })
     }
   })
 


### PR DESCRIPTION
This PR contains improved error handling for the SLP `txDetails()` endpoint. In reviewing our production error logs, this error occurs thousands of times per day:

```
Opening file main-prod-all.log
opening this file: /home/safeuser/rest-logs/src/commands/../../logs/main-prod-all.log
Error report:
Cnt: 57144
Msg: Error in slp.ts/txDetails().Cannot read property 'in' of undefined
stack trace: TypeError: Cannot read property 'in' of undefined
    at /var/www/rest.bitcoin.com/dist/routes/v2/slp.js:1924:34
    at step (/var/www/rest.bitcoin.com/dist/routes/v2/slp.js:43:23)
    at Object.next (/var/www/rest.bitcoin.com/dist/routes/v2/slp.js:24:53)
    at /var/www/rest.bitcoin.com/dist/routes/v2/slp.js:18:71
    at new Promise (<anonymous>)
    at __awaiter (/var/www/rest.bitcoin.com/dist/routes/v2/slp.js:14:12)
    at formatToRestObject (/var/www/rest.bitcoin.com/dist/routes/v2/slp.js:1917:12)
    at /var/www/rest.bitcoin.com/dist/routes/v2/slp.js:1844:42
    at step (/var/www/rest.bitcoin.com/dist/routes/v2/slp.js:43:23)
    at Object.next (/var/www/rest.bitcoin.com/dist/routes/v2/slp.js:24:53)
```

This error is not actually happening in the `txDetails()` function. It's happening in the `formatToRestObject()` sub-function. It happens when someone requests information on a non-slp transaction. 