### PR TITLE
Reduce error logs

### DIFF
--- a/src/routes/v2/slp.ts
+++ b/src/routes/v2/slp.ts
@@ -2103,7 +2103,9 @@ async function formatToRestObject(slpDBFormat: any) {
 
     return obj
   } catch (err) {
-    wlogger.error(`Error in slp.ts/formatToRestObject().`, err)
+    // This catch statement is regularly triggered as part of this functions
+    // normal behavior. Do not log errors.
+    // wlogger.error(`Error in slp.ts/formatToRestObject().`, err)
 
     return false
   }


### PR DESCRIPTION
Removes error logging in in the slp/formatToRestObject() function. This PR is an extension of PR #535. It's purpose is to reduce noise in our error logs.