### PR TITLE
fix(slp timeout): Fixing timout for axios for slp endpoints

### DIFF
--- a/src/routes/v2/slp.ts
+++ b/src/routes/v2/slp.ts
@@ -2654,9 +2654,9 @@ function generateCredentials() {
 
   const options = {
     headers: {
-      authorization: readyCredential,
-      timeout: 30000
-    }
+      authorization: readyCredential
+    },
+    timeout: 30000
   }
 
   return options


### PR DESCRIPTION
Fixes a typo that was preventing axios from timing out properly on slp endpoints.