### PR TITLE
v3 Address Utxo Route

### DIFF
--- a/docs/v3/api-spec.md
+++ b/docs/v3/api-spec.md
@@ -33,3 +33,35 @@ This document captures the specification for the new v3 routes.
   "addressSlp": <string>
 }
 ```
+
+## Address UTXO
+```
+{
+"address": <string>,
+"utxos": [
+      {
+        "txid": <string>,
+        "index": <number>,
+        "satoshis": <number>,
+        "height": <number>,
+        "slpData": {
+          "isSlp": <boolean>
+        }
+      },
+      {
+        "txid": <string>,
+        "index": <number>,
+        "satoshis": <number>,
+        "height": <number>,
+        "slpData": {
+          "isSlp": <boolean>,
+          "isValid": <boolean> | null,
+          "tokenId": <string>,
+          "decimals": <number>
+          "tokenAmount": <string>,
+  				"imageUrl": <string>
+        }
+      }
+    ]
+}
+```

--- a/src/routes/v3/address-new.js
+++ b/src/routes/v3/address-new.js
@@ -43,6 +43,7 @@ class Address {
     _this.router = router
     _this.router.get("/", this.root)
     _this.router.post("/balance", this.balance)
+    _this.router.post("/utxo", this.utxo)
   }
 
   root(req, res, next) {
@@ -50,7 +51,7 @@ class Address {
   }
 
   // Get the BCH balance for an array of addresses.
-  // curl -X POST "http://localhost:3000/v3/address/balance" -H "accept: application/json" -H "Content-Type: application/json" -d "{\"addresses\":[\"bitcoincash:qp3sn6vlwz28ntmf3wmyra7jqttfx7z6zgtkygjhc7\",\"bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v\"]}"
+  // curl -X POST "http://localhost:3000/v3-alpha/address/balance" -H "accept: application/json" -H "Content-Type: application/json" -d "{\"addresses\":[\"bitcoincash:qp3sn6vlwz28ntmf3wmyra7jqttfx7z6zgtkygjhc7\",\"bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v\"]}"
   async balance(req, res, next) {
     try {
       const addresses = req.body.addresses
@@ -120,9 +121,85 @@ class Address {
         return res.json({ error: msg })
       }
 
+      // If error could not be decoded.
       wlogger.error("Error in address-new.js/balance().", err)
+      res.status(500)
+      return res.json({ error: util.inspect(err) })
+    }
+  }
+
+  // Get UTXOs for an array of addresses.
+  // curl -X POST "http://localhost:3000/v3-alpha/address/utxo" -H "accept: application/json" -H "Content-Type: application/json" -d "{\"addresses\":[\"bitcoincash:qp3sn6vlwz28ntmf3wmyra7jqttfx7z6zgtkygjhc7\",\"bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v\"]}"
+  async utxo(req, res, next) {
+    try {
+      const addresses = req.body.addresses
+
+      // Reject if addresses is not an array.
+      if (!Array.isArray(addresses)) {
+        res.status(400)
+        return res.json({
+          error: "addresses needs to be an array."
+        })
+      }
+
+      // Enforce array size rate limits
+      if (!routeUtils.validateArraySize(req, addresses)) {
+        res.status(429) // https://github.com/Bitcoin-com/rest.bitcoin.com/issues/330
+        return res.json({
+          error: "Array too large."
+        })
+      }
+
+      // Validate each element in the address array.
+      for (let i = 0; i < addresses.length; i++) {
+        const thisAddress = addresses[i]
+        // Ensure the input is a valid BCH address.
+        try {
+          _this.bitbox.Address.toLegacyAddress(thisAddress)
+        } catch (err) {
+          res.status(400)
+          return res.json({
+            error: `Invalid BCH address. Double check your address is valid: ${thisAddress}`
+          })
+        }
+
+        // Prevent a common user error. Ensure they are using the correct network address.
+        const networkIsValid = _this.routeUtils.validateNetwork(
+          _this.bitbox.Address.toCashAddress(thisAddress)
+        )
+        if (!networkIsValid) {
+          res.status(400)
+          return res.json({
+            error: `Invalid network for address ${thisAddress}. Trying to use a testnet address on mainnet, or vice versa.`
+          })
+        }
+      }
+
+      const utxos = addresses.map(async (address, index) => {
+        // Get the data from the selected indexer.
+        if (_this.indexer === "BLOCKBOOK") return _this.blockbook.utxo(address)
+        return _this.ninsight.utxo(address)
+      })
+
+      // Wait for all promises to resolve.
+      const result = await Promise.all(utxos)
+      // console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      res.status(200)
+      return res.json(result)
+    } catch (err) {
+      // console.log(`err: `, err)
+      // console.log(`err: ${JSON.stringify(err, null, 2)}`)
+
+      // Attempt to decode the error message.
+      const { msg, status } = _this.routeUtils.decodeError(err)
+      if (msg) {
+        res.status(status)
+        return res.json({ error: msg })
+      }
 
       // If error could not be decoded.
+      wlogger.error("Error in address-new.js/utxo().", err)
       res.status(500)
       return res.json({ error: util.inspect(err) })
     }

--- a/src/routes/v3/services/blockbook.js
+++ b/src/routes/v3/services/blockbook.js
@@ -124,7 +124,7 @@ class Blockbook {
     } catch (err) {
       // Dev Note: Do not log error messages here. Throw them instead and let the
       // parent function handle it.
-      wlogger.debug("Error in blockbook.js/balance()")
+      wlogger.debug("Error in blockbook.js/utxo()")
       throw err
     }
   }

--- a/src/routes/v3/services/ninsight.js
+++ b/src/routes/v3/services/ninsight.js
@@ -30,8 +30,6 @@ class Ninsight {
   // Returns a Promise.
   async balance(thisAddress) {
     try {
-      // console.log(`BLOCKBOOK_URL: ${BLOCKBOOK_URL}`)
-
       // Convert the address to a cashaddr without a prefix.
       const addr = _this.bitbox.Address.toCashAddress(thisAddress)
 
@@ -67,6 +65,54 @@ class Ninsight {
       // Dev Note: Do not log error messages here. Throw them instead and let the
       // parent function handle it.
       wlogger.debug("Error in ninsight.js/balance()")
+      throw err
+    }
+  }
+
+  // Query the Ninsight API for UTXOs associated with a single BCH address.
+  // Returns a Promise.
+  async utxo(thisAddress) {
+    try {
+      // Convert the address to a cashaddr without a prefix.
+      const addr = _this.bitbox.Address.toCashAddress(thisAddress)
+
+      const path = `${NINSIGHT_URL}addr/${addr}/utxo`
+      // console.log(`path: ${path}`)
+
+      // Query the Blockbook Node API.
+      const axiosResponse = await _this.axios.get(path, axiosOptions)
+      const retData = axiosResponse.data
+      // console.log(`retData: ${JSON.stringify(retData, null, 2)}`)
+
+      const specUtxos = []
+
+      // Loops through each returned UTXO.
+      for (let i = 0; i < retData.length; i++) {
+        const thisUtxo = retData[i]
+
+        const specData = {
+          txid: thisUtxo.txid,
+          index: thisUtxo.vout,
+          satoshis: thisUtxo.satoshis,
+          height: thisUtxo.height,
+          slpData: {
+            isSlp: false
+          }
+        }
+
+        specUtxos.push(specData)
+      }
+
+      const outData = {
+        address: addr,
+        utxos: specUtxos
+      }
+
+      return outData
+    } catch (err) {
+      // Dev Note: Do not log error messages here. Throw them instead and let the
+      // parent function handle it.
+      wlogger.debug("Error in ninsight.js/utxo()")
       throw err
     }
   }

--- a/src/routes/v3/services/ninsight.js
+++ b/src/routes/v3/services/ninsight.js
@@ -10,7 +10,8 @@ const bitbox = new BITBOX()
 
 const NINSIGHT_URL = process.env.NINSIGHT_URL
   ? process.env.NINSIGHT_URL
-  : "https://bch-explorer.api.bitcoin.com/v1/"
+  : // : "https://bch-explorer.api.bitcoin.com/v1/"
+    "https://explorer.api.bitcoin.com/bch/v1/"
 
 const axiosOptions = { timeout: 15000 }
 

--- a/test/v3/integration/blockbook.integration.js
+++ b/test/v3/integration/blockbook.integration.js
@@ -18,7 +18,7 @@ describe("#Blockbook", () => {
       const addr = "bitcoincash:qp3sn6vlwz28ntmf3wmyra7jqttfx7z6zgtkygjhc7"
 
       const result = await uut.balance(addr)
-      console.log(`result: ${JSON.stringify(result, null, 2)}`)
+      // console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       // Ensure the returned value meets the specificiations in /docs/v3/api-spec.md
       assert.property(result, "balance")
@@ -50,6 +50,36 @@ describe("#Blockbook", () => {
       assert.isString(result.addressLegacy)
       assert.property(result, "addressSlp")
       assert.isString(result.addressSlp)
+    })
+  })
+
+  describe("#utxo", () => {
+    it("should retrieve BCH balance and output should comply with spec", async () => {
+      const addr = "bitcoincash:qp3sn6vlwz28ntmf3wmyra7jqttfx7z6zgtkygjhc7"
+
+      const result = await uut.utxo(addr)
+      console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.property(result, "address")
+
+      assert.property(result, "utxos")
+      assert.isArray(result.utxos)
+
+      assert.property(result.utxos[0], "txid")
+      assert.isString(result.utxos[0].txid)
+
+      assert.property(result.utxos[0], "index")
+      assert.isNumber(result.utxos[0].index)
+
+      assert.property(result.utxos[0], "satoshis")
+      assert.isNumber(result.utxos[0].satoshis)
+
+      assert.property(result.utxos[0], "height")
+      assert.isNumber(result.utxos[0].height)
+
+      assert.property(result.utxos[0], "slpData")
+      assert.property(result.utxos[0].slpData, "isSlp")
+      assert.equal(result.utxos[0].slpData.isSlp, false)
     })
   })
 })

--- a/test/v3/integration/blockbook.integration.js
+++ b/test/v3/integration/blockbook.integration.js
@@ -58,7 +58,7 @@ describe("#Blockbook", () => {
       const addr = "bitcoincash:qp3sn6vlwz28ntmf3wmyra7jqttfx7z6zgtkygjhc7"
 
       const result = await uut.utxo(addr)
-      console.log(`result: ${JSON.stringify(result, null, 2)}`)
+      // console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.property(result, "address")
 

--- a/test/v3/integration/ninsight.integration.js
+++ b/test/v3/integration/ninsight.integration.js
@@ -52,4 +52,34 @@ describe("#Ninsight", () => {
       assert.isString(result.addressSlp)
     })
   })
+
+  describe("#utxo", () => {
+    it("should retrieve BCH utxo and output should comply with spec", async () => {
+      const addr = "bitcoincash:qp3sn6vlwz28ntmf3wmyra7jqttfx7z6zgtkygjhc7"
+
+      const result = await uut.utxo(addr)
+      // console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.property(result, "address")
+
+      assert.property(result, "utxos")
+      assert.isArray(result.utxos)
+
+      assert.property(result.utxos[0], "txid")
+      assert.isString(result.utxos[0].txid)
+
+      assert.property(result.utxos[0], "index")
+      assert.isNumber(result.utxos[0].index)
+
+      assert.property(result.utxos[0], "satoshis")
+      assert.isNumber(result.utxos[0].satoshis)
+
+      assert.property(result.utxos[0], "height")
+      assert.isNumber(result.utxos[0].height)
+
+      assert.property(result.utxos[0], "slpData")
+      assert.property(result.utxos[0].slpData, "isSlp")
+      assert.equal(result.utxos[0].slpData.isSlp, false)
+    })
+  })
 })

--- a/test/v3/mocks/address-mock.js
+++ b/test/v3/mocks/address-mock.js
@@ -170,10 +170,26 @@ const mockBalance = {
   addressSlp: "simpleledger:qp3sn6vlwz28ntmf3wmyra7jqttfx7z6zg8d0n8hxq"
 }
 
+mockUtxo = {
+  address: "bitcoincash:qp3sn6vlwz28ntmf3wmyra7jqttfx7z6zgtkygjhc7",
+  utxos: [
+    {
+      txid: "6181c669614fa18039a19b23eb06806bfece1f7514ab457c3bb82a40fe171a6d",
+      index: 0,
+      satoshis: 1000,
+      height: 601861,
+      slpData: {
+        isSlp: false
+      }
+    }
+  ]
+}
+
 module.exports = {
   mockAddressDetails,
   mockUtxoDetails,
   mockUnconfirmed,
   mockTransactions,
-  mockBalance
+  mockBalance,
+  mockUtxo
 }

--- a/test/v3/mocks/blockbook-mock.js
+++ b/test/v3/mocks/blockbook-mock.js
@@ -16,6 +16,17 @@ const balance = {
   txids: ["6181c669614fa18039a19b23eb06806bfece1f7514ab457c3bb82a40fe171a6d"]
 }
 
+const utxo = [
+  {
+    txid: "6181c669614fa18039a19b23eb06806bfece1f7514ab457c3bb82a40fe171a6d",
+    vout: 0,
+    value: "1000",
+    height: 601861,
+    confirmations: 24163
+  }
+]
+
 module.exports = {
-  balance
+  balance,
+  utxo
 }

--- a/test/v3/mocks/ninsight-mock.js
+++ b/test/v3/mocks/ninsight-mock.js
@@ -19,6 +19,20 @@ const balance = {
   ]
 }
 
+utxo = [
+  {
+    address: "1A2fmjLeJXGbkQoTZDi2RdvcASGXgKEjvj",
+    txid: "6181c669614fa18039a19b23eb06806bfece1f7514ab457c3bb82a40fe171a6d",
+    vout: 0,
+    scriptPubKey: "76a9146309e99f709479af698bb641f7d202d693785a1288ac",
+    amount: 0.00001,
+    satoshis: 1000,
+    height: 601861,
+    confirmations: 24166
+  }
+]
+
 module.exports = {
-  balance
+  balance,
+  utxo
 }

--- a/test/v3/unit/blockbook.unit.js
+++ b/test/v3/unit/blockbook.unit.js
@@ -71,7 +71,7 @@ describe("#Blockbook", () => {
       assert.isString(result.addressSlp)
     })
 
-    it("should handle thrown errors", async () => {
+    it("should handle and throw errors", async () => {
       try {
         // Force axios to throw an error
         sandbox.stub(uut.axios, "get").rejects(new Error("ENETUNREACH"))
@@ -79,6 +79,55 @@ describe("#Blockbook", () => {
         const addr = "bitcoincash:qp3sn6vlwz28ntmf3wmyra7jqttfx7z6zgtkygjhc7"
 
         await uut.balance(addr)
+
+        assert.equal(true, false, "unexpected result")
+      } catch (err) {
+        assert.include(err.message, "ENETUNREACH")
+      }
+    })
+  })
+
+  describe("#utox", () => {
+    it("should retrieve BCH utxos and output should comply with spec", async () => {
+      // console.log(`mockData: ${JSON.stringify(mockData, null, 2)}`)
+
+      // Use mocks to prevent live network calls.
+      sandbox.stub(uut.axios, "get").resolves({ data: mockData.utxo })
+
+      const addr = "bitcoincash:qp3sn6vlwz28ntmf3wmyra7jqttfx7z6zgtkygjhc7"
+
+      const result = await uut.utxo(addr)
+
+      assert.property(result, "address")
+
+      assert.property(result, "utxos")
+      assert.isArray(result.utxos)
+
+      assert.property(result.utxos[0], "txid")
+      assert.isString(result.utxos[0].txid)
+
+      assert.property(result.utxos[0], "index")
+      assert.isNumber(result.utxos[0].index)
+
+      assert.property(result.utxos[0], "satoshis")
+      assert.isNumber(result.utxos[0].satoshis)
+
+      assert.property(result.utxos[0], "height")
+      assert.isNumber(result.utxos[0].height)
+
+      assert.property(result.utxos[0], "slpData")
+      assert.property(result.utxos[0].slpData, "isSlp")
+      assert.equal(result.utxos[0].slpData.isSlp, false)
+    })
+
+    it("should handle and throw errors", async () => {
+      try {
+        // Force axios to throw an error
+        sandbox.stub(uut.axios, "get").rejects(new Error("ENETUNREACH"))
+
+        const addr = "bitcoincash:qp3sn6vlwz28ntmf3wmyra7jqttfx7z6zgtkygjhc7"
+
+        await uut.utxo(addr)
 
         assert.equal(true, false, "unexpected result")
       } catch (err) {

--- a/test/v3/unit/ninsight.unit.js
+++ b/test/v3/unit/ninsight.unit.js
@@ -86,4 +86,55 @@ describe("#Ninsight", () => {
       }
     })
   })
+
+  describe("#utxo", () => {
+    it("should retrieve BCH balance and output should comply with spec", async () => {
+      // console.log(`mockData: ${JSON.stringify(mockData, null, 2)}`)
+
+      // Use mocks to prevent live network calls.
+      sandbox.stub(uut.axios, "get").resolves({ data: mockData.utxo })
+
+      const addr = "bitcoincash:qp3sn6vlwz28ntmf3wmyra7jqttfx7z6zgtkygjhc7"
+
+      const result = await uut.utxo(addr)
+      // console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      // Ensure the returned value meets the specificiations in /docs/v3/api-spec.md
+      assert.property(result, "address")
+
+      assert.property(result, "utxos")
+      assert.isArray(result.utxos)
+
+      assert.property(result.utxos[0], "txid")
+      assert.isString(result.utxos[0].txid)
+
+      assert.property(result.utxos[0], "index")
+      assert.isNumber(result.utxos[0].index)
+
+      assert.property(result.utxos[0], "satoshis")
+      assert.isNumber(result.utxos[0].satoshis)
+
+      assert.property(result.utxos[0], "height")
+      assert.isNumber(result.utxos[0].height)
+
+      assert.property(result.utxos[0], "slpData")
+      assert.property(result.utxos[0].slpData, "isSlp")
+      assert.equal(result.utxos[0].slpData.isSlp, false)
+    })
+
+    it("should handle thrown errors", async () => {
+      try {
+        // Force axios to throw an error
+        sandbox.stub(uut.axios, "get").rejects(new Error("ENETUNREACH"))
+
+        const addr = "bitcoincash:qp3sn6vlwz28ntmf3wmyra7jqttfx7z6zgtkygjhc7"
+
+        await uut.utxo(addr)
+
+        assert.equal(true, false, "unexpected result")
+      } catch (err) {
+        assert.include(err.message, "ENETUNREACH")
+      }
+    })
+  })
 })


### PR DESCRIPTION
Includes integration tests and 100% unit test coverage.

To test:
`curl -X POST "http://localhost:3000/v3-alpha/address/utxo" -H "accept: application/json" -H "Content-Type: application/json" -d "{\"addresses\":[\"bitcoincash:qp3sn6vlwz28ntmf3wmyra7jqttfx7z6zgtkygjhc7\",\"bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v\"]}"`