### PR TITLE
Removed link to trest.bitcoin.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 More info: [developer.bitcoin.com](https://developer.bitcoin.com). Chatroom [http://geni.us/CashDev](geni.us/CashDev)
 
-Testnet available at [trest.bitcoin.com](https://trest.bitcoin.com)
-
 ## Usage
 
 You can also run an instance of REST for your own full node.


### PR DESCRIPTION
As trest.bitcoin.com is no longer operational.

I also suggest that a proper message is returned instead of `Network error: Could not communicate with full node or other external service.` for API calls.