### PR TITLE
use toString method to retrieve proper type

### DIFF
--- a/src/routes/v2/address.ts
+++ b/src/routes/v2/address.ts
@@ -110,7 +110,7 @@ async function detailsSingle(
   try {
     const address: string = req.params.address
     const currentPage: number = req.query.page
-      ? parseInt(req.query.page, 10)
+      ? parseInt(req.query.page.toString(), 10)
       : 0
 
     if (!address || address === "") {
@@ -762,7 +762,7 @@ async function transactionsSingle(
   try {
     const address: string = req.params.address
     const currentPage: number = req.query.page
-      ? parseInt(req.query.page, 10)
+      ? parseInt(req.query.page.toString(), 10)
       : 0
 
     if (!address || address === "") {
@@ -841,7 +841,7 @@ async function fromXPubSingle(
 ): Promise<express.Response> {
   try {
     const xpub: string = req.params.xpub
-    const hdPath: string = req.query.hdPath ? req.query.hdPath : "0"
+    const hdPath: string = req.query.hdPath ? req.query.hdPath.toString() : "0"
 
     if (!xpub || xpub === "") {
       res.status(400)

--- a/src/routes/v2/mining.ts
+++ b/src/routes/v2/mining.ts
@@ -87,8 +87,8 @@ async function getNetworkHashPS(
   try {
     let nblocks: number = 120 // Default
     let height: number = -1 // Default
-    if (req.query.nblocks) nblocks = parseInt(req.query.nblocks)
-    if (req.query.height) height = parseInt(req.query.height)
+    if (req.query.nblocks) nblocks = parseInt(req.query.nblocks.toString())
+    if (req.query.height) height = parseInt(req.query.height.toString())
 
     const { BitboxHTTP, requestConfig } = routeUtils.setEnvVars()
 

--- a/src/routes/v2/slp.ts
+++ b/src/routes/v2/slp.ts
@@ -2346,7 +2346,7 @@ async function txsByAddressSingle(
     }
 
     const fromBlock: number = req.query.fromBlock
-      ? parseInt(req.query.fromBlock, 10)
+      ? parseInt(req.query.fromBlock.toString(), 10)
       : 0
 
     // Ensure the input is a valid BCH address.

--- a/src/routes/v3/address.ts
+++ b/src/routes/v3/address.ts
@@ -110,7 +110,7 @@ async function detailsSingle(
   try {
     const address: string = req.params.address
     const currentPage: number = req.query.page
-      ? parseInt(req.query.page, 10)
+      ? parseInt(req.query.page.toString(), 10)
       : 0
 
     if (!address || address === "") {
@@ -762,7 +762,7 @@ async function transactionsSingle(
   try {
     const address: string = req.params.address
     const currentPage: number = req.query.page
-      ? parseInt(req.query.page, 10)
+      ? parseInt(req.query.page.toString(), 10)
       : 0
 
     if (!address || address === "") {
@@ -841,7 +841,7 @@ async function fromXPubSingle(
 ): Promise<express.Response> {
   try {
     const xpub: string = req.params.xpub
-    const hdPath: string = req.query.hdPath ? req.query.hdPath : "0"
+    const hdPath: string = req.query.hdPath ? req.query.hdPath.toString() : "0"
 
     if (!xpub || xpub === "") {
       res.status(400)

--- a/src/routes/v3/mining.ts
+++ b/src/routes/v3/mining.ts
@@ -87,8 +87,8 @@ async function getNetworkHashPS(
   try {
     let nblocks: number = 120 // Default
     let height: number = -1 // Default
-    if (req.query.nblocks) nblocks = parseInt(req.query.nblocks)
-    if (req.query.height) height = parseInt(req.query.height)
+    if (req.query.nblocks) nblocks = parseInt(req.query.nblocks.toString())
+    if (req.query.height) height = parseInt(req.query.height.toString())
 
     const { BitboxHTTP, requestConfig } = routeUtils.setEnvVars()
 


### PR DESCRIPTION
This utitlizes the `toString` method of the query parser to extract a string value from the request parameters. This resolves #574 

https://expressjs.com/en/api.html#req.query